### PR TITLE
fix: parse endpoints as expressions

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -15,6 +15,7 @@
   and @left,
   or @left,
   unaryTest @cut,
+  filterExpression @left,
   then @left,
   else @left,
   paren,
@@ -106,7 +107,7 @@ PathExpression {
 }
 
 filterExpressionStart[@export] {
-  "["
+  "[" !filterExpression
 }
 
 FilterExpression {
@@ -291,8 +292,7 @@ PositionalParameters {
 }
 
 endpoint {
-  QualifiedName |
-  simpleLiteral
+  expression
 }
 
 nil[@export] {

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -121,13 +121,14 @@ Expressions(
 
 
 # ParenthesizedExpression
-
 (a);
-(a + b) * c
+(a.b = 10);
+(a + b) * c;
 
 ==>
 
 Expressions(
+  ParenthesizedExpression(...),
   ParenthesizedExpression(...),
   ArithmeticExpression(...)
 )
@@ -551,9 +552,9 @@ Expressions(
 ==>
 
 Expressions(
-  SimplePositiveUnaryTest(Interval("[",QualifiedName(VariableName(...)),QualifiedName(VariableName(...)),"]")),
-  SimplePositiveUnaryTest(Interval("(",QualifiedName(VariableName(...)),QualifiedName(VariableName(...)),")")),
-  SimplePositiveUnaryTest(Interval("]",QualifiedName(VariableName(...)),QualifiedName(VariableName(...)),"[")),
+  SimplePositiveUnaryTest(Interval("[",VariableName(...),VariableName(...),"]")),
+  SimplePositiveUnaryTest(Interval("(",VariableName(...),VariableName(...),")")),
+  SimplePositiveUnaryTest(Interval("]",VariableName(...),VariableName(...),"[")),
   SimplePositiveUnaryTest(Interval("[",NumericLiteral,NumericLiteral,"]")),
   SimplePositiveUnaryTest(Interval("(",NumericLiteral,NumericLiteral,")")),
   SimplePositiveUnaryTest(Interval("]",NumericLiteral,NumericLiteral,"["))
@@ -568,7 +569,7 @@ Expressions(
 
 Expressions(
   SimplePositiveUnaryTest(
-    Interval("[",QualifiedName(VariableName(...),VariableName(...)),QualifiedName(VariableName(...)),"]")
+    Interval("[",PathExpression(VariableName(...),VariableName(...)),VariableName(...),"]")
   )
 )
 
@@ -581,8 +582,8 @@ Expressions(
 ==>
 
 Expressions(
-  SimplePositiveUnaryTest(Interval("[",QualifiedName(VariableName(...)),QualifiedName(VariableName(...)),⚠)),
-  SimplePositiveUnaryTest(Interval("[",QualifiedName(VariableName(...)),⚠))
+  SimplePositiveUnaryTest(Interval("[",VariableName(...),VariableName(...),⚠)),
+  SimplePositiveUnaryTest(Interval("[",VariableName(...),⚠))
 )
 
 
@@ -590,6 +591,7 @@ Expressions(
 
 []
 [1]
+[a.b.c]
 [1 + 3, 2 * 5];
 [a, [1, { a: 1 } ], [], [1 .. 3], (1) ]
 
@@ -598,6 +600,7 @@ Expressions(
 Expressions(
   List("[","]"),
   List("[",NumericLiteral,"]"),
+  List("[",PathExpression(...),"]"),
   List("[",ArithmeticExpression(...),ArithmeticExpression(...),"]"),
   List(...)
 )
@@ -611,7 +614,7 @@ Expressions(
 ==>
 
 Expressions(
-  SimplePositiveUnaryTest(Interval("[",QualifiedName(...),⚠)),
+  SimplePositiveUnaryTest(Interval("[",VariableName(...),⚠)),
   List("[",⚠)
 )
 
@@ -2038,8 +2041,8 @@ Expressions(
 
 Expressions(
   SimplePositiveUnaryTest(CompareOp,NumericLiteral),
-  SimplePositiveUnaryTest(CompareOp,QualifiedName(...)),
-  SimplePositiveUnaryTest(CompareOp,QualifiedName(...))
+  SimplePositiveUnaryTest(CompareOp,VariableName(...)),
+  SimplePositiveUnaryTest(CompareOp,PathExpression(...))
 )
 
 

--- a/test/unary-tests.txt
+++ b/test/unary-tests.txt
@@ -67,6 +67,25 @@ UnaryTests(PositiveUnaryTests(
 ))
 
 
+# Interval { "top": "UnaryTests" }
+
+[ a.b.c .. e f.g ]
+
+==>
+
+UnaryTests(
+  PositiveUnaryTests(
+    PositiveUnaryTest(
+      SimplePositiveUnaryTest(
+        Interval("[",
+          PathExpression(...),
+          PathExpression(...),
+        "]")
+      )
+    )
+  )
+)
+
 
 # Negation { "top": "UnaryTests" }
 

--- a/test/unary-tests.txt
+++ b/test/unary-tests.txt
@@ -67,25 +67,6 @@ UnaryTests(PositiveUnaryTests(
 ))
 
 
-# QualifiedName { "top": "UnaryTests" }
-
-[ a.b.c .. e f.g ]
-
-==>
-
-UnaryTests(
-  PositiveUnaryTests(
-    PositiveUnaryTest(
-      SimplePositiveUnaryTest(
-        Interval("[",
-          QualifiedName(...),
-          QualifiedName(...),
-        "]")
-      )
-    )
-  )
-)
-
 
 # Negation { "top": "UnaryTests" }
 


### PR DESCRIPTION
__Which issue does this PR address?__

Closes #12, #11

Make `endpoint` an expression in accordance with the FEEL spec

![image](https://user-images.githubusercontent.com/21984219/202258144-b6e1f72c-c4a1-4d22-a8c1-d718d820489a.png)
