### PR TITLE
fix(build): allow building on windows systems

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ export default {
       sourcemap: true
     }
   ],
-  external(id) { return !/^[./]/.test(id); },
+  external: Object.keys(pkg.dependencies),
   plugins: [
     nodeResolve()
   ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,10 @@ export default {
       sourcemap: true
     }
   ],
-  external: Object.keys(pkg.dependencies),
+  external(id) {
+    return Object.keys(pkg.dependencies)
+      .includes(id.split('/')[0]);
+  },
   plugins: [
     nodeResolve()
   ]


### PR DESCRIPTION
Currently, the library can not be built on windows machines (cf. https://github.com/bpmn-io/variable-resolver/actions/runs/4182976804/jobs/7246748334 )

```
npm ERR! src/index.js → dist/index.cjs, dist/index.es.js...
npm ERR! [!] Error: Entry module cannot be external (src/index.js).
npm ERR! Error: Entry module cannot be external (src/index.js).
```

This PR ensures that external dependencies are defined without path-specific characteristics. (cf. successful windows CI run on branch: https://github.com/bpmn-io/variable-resolver/actions/runs/4183105386/jobs/7247038089 )