### PR TITLE
fix(build): bundle namespaced dependencies

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ export default {
   ],
   external(id) {
     return Object.keys(pkg.dependencies)
-      .includes(id.split('/')[0]);
+      .find(dep => id.startsWith(dep));
   },
   plugins: [
     nodeResolve()


### PR DESCRIPTION
Follow-up from https://github.com/nikku/lezer-feel/pull/20#discussion_r1115427813

I verified that 
 1. On master, `@lezer` packages were inlined in the bundle
 2. With this PR they are external and imported
 3. it still works on windows