### PR TITLE
fix(VariableContext): make `isAtomic` a static function

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -14,7 +14,7 @@ export class VariableContext {
 
   getKeys(): string[];
 
-  isAtomic(value: any): boolean;
+  static isAtomic(value: any): boolean;
 
   static of(...values: ContextValue[]): VariableContext;
 }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -470,7 +470,7 @@ export class VariableContext {
   get(key) {
     const result = this.value[key];
 
-    if (this.isAtomic(result)) {
+    if (this.constructor.isAtomic(result)) {
       return result;
     }
 
@@ -498,9 +498,9 @@ export class VariableContext {
    * @param {any} value
    * @returns {Boolean}
    */
-  isAtomic(value) {
+  static isAtomic(value) {
     return !value ||
-          value instanceof this.constructor ||
+          value instanceof this ||
           value instanceof ValueProducer ||
           typeof value !== 'object';
   }

--- a/test/test-feel.js
+++ b/test/test-feel.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai';
+
 import { parser, trackVariables, VariableContext } from 'lezer-feel';
 import { testTree } from '@lezer/generator/dist/test';
 import { buildParser } from '@lezer/generator';
@@ -205,6 +207,21 @@ for (const file of fs.readdirSync(caseDir)) {
   });
 
 }
+
+
+describe('Custom Context', function() {
+
+  it('should create context from literals', function() {
+
+    const context = EntriesContext.of(15);
+
+    // then
+    expect(context.value.atomicValue).to.exist;
+    expect(context.value.atomicValue).to.equal(15);
+
+  });
+
+});
 
 /**
  * An alternative context that holds additional meta-data

--- a/test/test-feel.js
+++ b/test/test-feel.js
@@ -218,7 +218,7 @@ class EntriesContext extends VariableContext {
     for (const key in this.value.entries) {
       const entry = this.value.entries[key];
 
-      if (!this.isAtomic(entry)) {
+      if (!this.constructor.isAtomic(entry)) {
         this.value.entries[key] = this.constructor.of(this.value.entries[key]);
       }
     }
@@ -246,12 +246,10 @@ class EntriesContext extends VariableContext {
 
   static of(...contexts) {
     const unwrap = (context) => {
-      if (!context || typeof context !== 'object') {
-        return {};
-      }
-
-      if (context instanceof this) {
-        return context.value;
+      if (this.isAtomic(context)) {
+        return context instanceof this ?
+          context.value :
+          { atomicValue: context };
       }
 
       return { ...context };


### PR DESCRIPTION
- `isAtomic` does not access instance specific variables
- Using it in `of` allows the user to keep details of atomic value (e.g. type and value)