### PR TITLE
test: verify expression parses with error

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -858,7 +858,7 @@ function wrap(variables, scopeName, code) {
   const namePart = parts[0];
   const valuePart = parts[Math.max(1, parts.length - 1)];
 
-  const name = namePart.computedValue();
+  const name = namePart?.computedValue();
   const value = valuePart?.computedValue() || null;
 
   return variables
@@ -986,7 +986,7 @@ export function trackVariables(context = {}, Context = VariableContext) {
           {
             value: Context
               .of(variables.value)
-              .set(name.computedValue(), value?.computedValue())
+              .set(name?.computedValue(), value?.computedValue())
           }
         );
       }

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -482,6 +482,36 @@ Expression(
 )
 
 
+# Context (error, empty entry)
+
+{
+  "key": {
+    nested key: v + ^{}"
+  }
+}
+
+==>
+
+Expression(
+  Context("{",
+    ContextEntry(
+      Key(...),
+      Context("{",
+        ContextEntry(
+          Key(...),
+          ArithmeticExpression(
+            ArithmeticExpression(VariableName(...),ArithOp,⚠),
+            ArithOp,
+            Context("{","}"),
+            ⚠
+          )
+        ),
+      "}")
+    ),
+  "}")
+)
+
+
 # Context (special key)
 
 {


### PR DESCRIPTION
The following expression should parse with an syntax error:

```
{
 "key": {
   "smth": v + ^{}"
  }
}
```

Instead it fails to parse all together:

```
TypeError: Cannot read properties of undefined (reading 'computedValue')
```