### PR TITLE
fix: correct recovery of positional parameters

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -105,7 +105,7 @@ pathExpressionStart[@export] {
   "."
 }
 
-PathExpression {
+PathExpression[@dynamicPrecedence=1] {
   expression !path pathExpressionStart VariableName
 }
 

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -1654,6 +1654,35 @@ Expressions(
 )
 
 
+# FunctionInvocation (positional, error) { "top": "Expressions" }
+
+bar(foo., bazzzzzz);
+bar(foo., baz)
+
+==>
+
+Expressions(
+
+  FunctionInvocation(VariableName(...), "(",
+    PositionalParameters(
+      PathExpression(
+        VariableName(...), ⚠
+      ),
+      VariableName(...)
+    ),
+  ")"),
+
+  FunctionInvocation(VariableName(...), "(",
+    PositionalParameters(
+      PathExpression(
+        VariableName(...), ⚠
+      ),
+      VariableName(...)
+    ),
+  ")")
+)
+
+
 # FunctionInvocation (named) { "top": "Expressions" }
 
 a(foo: f, bar: b, other: o);
@@ -1676,6 +1705,64 @@ Expressions(
     NamedParameter(ParameterName(...),VariableName(...)),
     NamedParameter(ParameterName(...),VariableName(...))
   ),")")
+)
+
+
+# FunctionInvocation (named, error) { "top": "Expressions" }
+
+bar(foo: foo., baz: bazzzzzz);
+bar(foo: foo., baz: baz);
+bar(foo: foo., bazzzzzz);
+bar(foo: foo., baz)
+
+==>
+
+Expressions(
+
+  FunctionInvocation(VariableName(Identifier),"(",
+    NamedParameters(
+      NamedParameter(
+        ParameterName(...),
+        PathExpression(VariableName(...),⚠)
+      ),
+      NamedParameter(
+        ParameterName(...),
+        VariableName(...)
+      )
+    ),
+  ")"),
+
+  FunctionInvocation(VariableName(Identifier),"(",
+    NamedParameters(
+      NamedParameter(
+        ParameterName(...),
+        PathExpression(VariableName(...),⚠)
+      ),
+      NamedParameter(
+        ParameterName(...),
+        VariableName(...)
+      )
+    ),
+  ")"),
+
+  FunctionInvocation(VariableName(Identifier),"(",
+    NamedParameters(
+      NamedParameter(
+        ParameterName(...),
+        PathExpression(VariableName(...),⚠,VariableName(...))
+      )
+    ),
+  ")"),
+
+  FunctionInvocation(VariableName(Identifier),"(",
+    NamedParameters(
+      NamedParameter(
+        ParameterName(...),
+        PathExpression(VariableName(...),⚠,VariableName(...))
+      )
+    ),
+  ")")
+
 )
 
 


### PR DESCRIPTION
We'd otherwise recover incomplete path expressions inside function invocations as `NamedParameters` rather than `PositionalParameters`.

Before this change:

```
// correctly handled as positional (with error)
bar(foo., baz)

// incorrectly handled as named
bar(foo., bazzzzzz)
```

### Which issue does this PR address?

None, found during testing.
