### PR TITLE
Support deep context merging

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -19,6 +19,8 @@ export class VariableContext {
 
   getKeys(): string[];
 
+  merge(other: ContextValue) : VariableContext
+
   static isAtomic(value: any): boolean;
 
   static of(...values: ContextValue[]): VariableContext;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.1",
-        "@lezer/lr": "^1.4.2"
+        "@lezer/lr": "^1.4.2",
+        "min-dash": "^4.2.1"
       },
       "devDependencies": {
         "@lezer/generator": "^1.7.1",
@@ -2876,6 +2877,12 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/min-dash": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
+      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@lezer/highlight": "^1.2.1",
-    "@lezer/lr": "^1.4.2"
+    "@lezer/lr": "^1.4.2",
+    "min-dash": "^4.2.1"
   },
   "engines": {
     "node": "*"

--- a/test/custom-context.js
+++ b/test/custom-context.js
@@ -1,0 +1,96 @@
+import { VariableContext } from 'lezer-feel';
+
+
+/**
+ * An alternative context that holds additional meta-data
+ */
+export class EntriesContext extends VariableContext {
+
+  constructor(value = { entries: {} }) {
+    super(value);
+
+    this.value.entries = this.value.entries || {};
+    for (const key in this.value.entries) {
+      const entry = this.value.entries[key];
+
+      const constructor = /** @type { typeof EntriesContext } */ (this.constructor);
+
+      if (!constructor.isAtomic(entry)) {
+        this.value.entries[key] = constructor.of(this.value.entries[key]);
+      }
+    }
+  }
+
+  getKeys() {
+    return Object.keys(this.value.entries);
+  }
+
+  get(key) {
+    return this.value.entries[key];
+  }
+
+  /**
+   * @param {string} key
+   * @param {any} value
+   *
+   * @return {this}
+   */
+  set(key, value) {
+
+    const constructor = /** @type { typeof EntriesContext } */ (this.constructor);
+
+    return /** @type {this} */ (constructor.of(
+      {
+        ...this.value,
+        entries: {
+          ...this.value.entries,
+          [key]: value
+        }
+      }
+    ));
+  }
+
+  static of(...contexts) {
+    const unwrap = (context) => {
+      if (this.isAtomic(context)) {
+        return context instanceof this ?
+          context.value :
+          { atomicValue: context };
+      }
+
+      return { ...context };
+    };
+
+    const merged = contexts.reduce((merged, context) => {
+
+      const {
+        entries = {},
+        ...rest
+      } = unwrap(context);
+
+      return {
+        ...merged,
+        ...rest,
+        entries: {
+          ...merged.entries,
+          ...entries
+        }
+      };
+    }, {});
+
+    return new this(merged);
+  }
+}
+
+
+export function toEntriesContextValue(context) {
+
+  return context && Object.keys(context).reduce((result, key) => {
+    const value = context[key];
+
+    result.entries[key] = typeof value === 'object' ? toEntriesContextValue(value)
+      : value;
+
+    return result;
+  }, { entries: {} });
+}

--- a/test/custom-context.js
+++ b/test/custom-context.js
@@ -1,11 +1,20 @@
-import { VariableContext } from 'lezer-feel';
+import {
+  VariableContext
+} from 'lezer-feel';
 
+
+/**
+ * @typedef { { entries?: Record<string, any>, [key: string]: any } } EntriesContextValue
+ */
 
 /**
  * An alternative context that holds additional meta-data
  */
 export class EntriesContext extends VariableContext {
 
+  /**
+   * @param {EntriesContextValue} value
+   */
   constructor(value = { entries: {} }) {
     super(value);
 
@@ -50,35 +59,50 @@ export class EntriesContext extends VariableContext {
     ));
   }
 
-  static of(...contexts) {
-    const unwrap = (context) => {
-      if (this.isAtomic(context)) {
-        return context instanceof this ?
-          context.value :
-          { atomicValue: context };
-      }
+  /**
+   * @param { EntriesContext | EntriesContextValue | Record<string, any> } context
+   *
+   * @return { EntriesContextValue }
+   */
+  static __unwrap(context) {
 
-      return { ...context };
+    if (this.isAtomic(context)) {
+      return context instanceof this
+        ? context.value
+        : { atomicValue: context };
+    }
+
+    return {
+      ...context
     };
+  }
 
-    const merged = contexts.reduce((merged, context) => {
+  /**
+   * @param { EntriesContextValue } context
+   * @param { EntriesContextValue} other
+   *
+   * @return { EntriesContextValue }
+   */
+  static __merge(context, other) {
 
-      const {
-        entries = {},
-        ...rest
-      } = unwrap(context);
+    const {
+      entries: contextEntries = {},
+      ...contextRest
+    } = this.__unwrap(context);
 
-      return {
-        ...merged,
-        ...rest,
-        entries: {
-          ...merged.entries,
-          ...entries
-        }
-      };
-    }, {});
+    const {
+      entries: otherEntries = {},
+      ...otherRest
+    } = this.__unwrap(other);
 
-    return new this(merged);
+    // @ts-ignore "access to internals"
+    const mergedEntries = super.__merge(contextEntries, otherEntries);
+
+    return {
+      ...contextRest,
+      ...otherRest,
+      entries: mergedEntries
+    };
   }
 }
 

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -555,7 +555,6 @@ Expression(
 )
 
 
-
 # Context (special, scope)  { "context": { "foo + bar": 100 } }
 
 {
@@ -667,6 +666,7 @@ Expression(
     )),
   "}")
 )
+
 
 
 # Context / FunctionDefinition / FunctionInvocation
@@ -1375,23 +1375,20 @@ for i in [1] return if i = 1 then { a+: 1 } else partial[-1].a+
 
 Expression(
   ForExpression(
-    for,InExpressions(
-      InExpression(Name(...),in,IterationContext(
-        List("[",NumericLiteral,"]")
-      ))
-    ),
-    return,IfExpression(
-      if,Comparison(
-        VariableName(...),CompareOp,NumericLiteral
-      ),
-      then, Context("{",
-        ContextEntry(Key(Name(...)),NumericLiteral),
-      "}"),
-      else,PathExpression(
-        FilterExpression(VariableName(...),"[",NumericLiteral(ArithOp),"]"),
-        VariableName(...)
+    for,
+      InExpressions(...),
+    return,
+      IfExpression(
+        if,
+          Comparison(...),
+        then,
+          Context(...),
+        else,
+          PathExpression(
+            FilterExpression(VariableName(...),"[",NumericLiteral(...),"]"),
+            VariableName(...)
+          )
       )
-    )
   )
 )
 
@@ -1531,6 +1528,32 @@ Expression(
         "}")
       ),
     ")"),
+    VariableName(...)
+  )
+)
+
+
+# IfExpression (special, nested merged context)
+
+(if true then { a: { a+: 1 } } else { a: { a-: 1 } }).a.a+
+
+==>
+
+Expression(
+  PathExpression(
+    PathExpression(
+      ParenthesizedExpression("(",
+        IfExpression(
+          if,
+            BooleanLiteral,
+          then,
+            Context(...),
+          else,
+            Context(...)
+        ),
+      ")"),
+      VariableName(...)
+    ),
     VariableName(...)
   )
 )

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -3,20 +3,103 @@ import {
 } from 'chai';
 
 import {
-  EntriesContext
+  EntriesContext,
+  toEntriesContextValue
 } from './custom-context.js';
 
 
 describe('custom context', function() {
 
-  it('should create context from literals', function() {
+  it('should create from literal', function() {
 
     const context = EntriesContext.of(15);
 
     // then
     expect(context.value.atomicValue).to.exist;
     expect(context.value.atomicValue).to.equal(15);
+  });
 
+
+  it('should create from context value', function() {
+
+    const context = EntriesContext.of({
+      entries: {
+        a: {
+          entries: {
+            ab: 10
+          }
+        }
+      }
+    });
+
+    // then
+    expect(context.value).to.have.key('entries');
+
+    // expose nested entry
+    expect(context.value.entries.a.value.entries.ab).to.eql({
+      value: { atomicValue: 10, entries: {} }
+    });
+  });
+
+
+  it('should create value via utility', function() {
+
+    const context = EntriesContext.of(toEntriesContextValue({
+      a: { ab: 10 }
+    }));
+
+    // then
+    expect(context.value).to.have.key('entries');
+
+    // expose nested entry
+    expect(context.value.entries.a.value.entries.ab).to.eql({
+      value: { atomicValue: 10, entries: {} }
+    });
+  });
+
+
+  it('should merge contexts', function() {
+
+    // when
+    const context = EntriesContext.of(
+      EntriesContext.of(
+        toEntriesContextValue({
+          a: { ab: 10 }
+        })
+      ),
+      EntriesContext.of(
+        toEntriesContextValue({
+          a: { ac: 20 }
+        })
+      )
+    );
+
+    // then
+    expect(context.value.entries.a.value.entries).to.have.keys([ 'ab', 'ac' ]);
+  });
+
+
+  it('should merge, unwraping nested contexts', function() {
+
+    const context = EntriesContext.of(
+      EntriesContext.of({
+        entries: {
+          a: EntriesContext.of(
+            {
+              entries: { ab: 10 }
+            }
+          )
+        }
+      }),
+      EntriesContext.of({
+        entries: {
+          a: { ac: 20 }
+        }
+      })
+    );
+
+    // then
+    expect(context).to.exist;
   });
 
 });

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -1,0 +1,22 @@
+import {
+  expect
+} from 'chai';
+
+import {
+  EntriesContext
+} from './custom-context.js';
+
+
+describe('custom context', function() {
+
+  it('should create context from literals', function() {
+
+    const context = EntriesContext.of(15);
+
+    // then
+    expect(context.value.atomicValue).to.exist;
+    expect(context.value.atomicValue).to.equal(15);
+
+  });
+
+});

--- a/test/test-feel.js
+++ b/test/test-feel.js
@@ -1,14 +1,23 @@
 import { expect } from 'chai';
 
-import { parser, trackVariables, VariableContext } from 'lezer-feel';
 import { testTree } from '@lezer/generator/dist/test';
 import { buildParser } from '@lezer/generator';
+
+import {
+  parser,
+  trackVariables
+} from 'lezer-feel';
 
 import fs from 'node:fs';
 import path from 'node:path';
 
 import { fileURLToPath } from 'node:url';
 import { ContextTracker } from '@lezer/lr';
+
+import {
+  EntriesContext,
+  toEntriesContextValue
+} from './custom-context.js';
 
 const caseDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -229,113 +238,4 @@ for (const file of fs.readdirSync(caseDir)) {
 
   });
 
-}
-
-
-describe('Custom Context', function() {
-
-  it('should create context from literals', function() {
-
-    const context = EntriesContext.of(15);
-
-    // then
-    expect(context.value.atomicValue).to.exist;
-    expect(context.value.atomicValue).to.equal(15);
-
-  });
-
-});
-
-/**
- * An alternative context that holds additional meta-data
- */
-class EntriesContext extends VariableContext {
-
-  constructor(value = { entries: {} }) {
-    super(value);
-
-    this.value.entries = this.value.entries || {};
-    for (const key in this.value.entries) {
-      const entry = this.value.entries[key];
-
-      const constructor = /** @type { typeof EntriesContext } */ (this.constructor);
-
-      if (!constructor.isAtomic(entry)) {
-        this.value.entries[key] = constructor.of(this.value.entries[key]);
-      }
-    }
-  }
-
-  getKeys() {
-    return Object.keys(this.value.entries);
-  }
-
-  get(key) {
-    return this.value.entries[key];
-  }
-
-  /**
-   * @param {string} key
-   * @param {any} value
-   *
-   * @return {this}
-   */
-  set(key, value) {
-
-    const constructor = /** @type { typeof EntriesContext } */ (this.constructor);
-
-    return /** @type {this} */ (constructor.of(
-      {
-        ...this.value,
-        entries: {
-          ...this.value.entries,
-          [key]: value
-        }
-      }
-    ));
-  }
-
-  static of(...contexts) {
-    const unwrap = (context) => {
-      if (this.isAtomic(context)) {
-        return context instanceof this ?
-          context.value :
-          { atomicValue: context };
-      }
-
-      return { ...context };
-    };
-
-    const merged = contexts.reduce((merged, context) => {
-
-      const {
-        entries = {},
-        ...rest
-      } = unwrap(context);
-
-      return {
-        ...merged,
-        ...rest,
-        entries: {
-          ...merged.entries,
-          ...entries
-        }
-      };
-    }, {});
-
-    return new this(merged);
-  }
-}
-
-
-function toEntriesContextValue(context) {
-
-  return context && Object.keys(context).reduce((result, key) => {
-    const value = context[key];
-
-    result.entries[key] = typeof value === 'object' ? toEntriesContextValue(value)
-      : value;
-
-    return result;
-  }, { entries: {} });
 }


### PR DESCRIPTION
### Which issue does this PR address?

This PR implements (nested) context merging, so things like [this](https://nikku.github.io/feel-playground/?e=%7E3YCAkIDYgICAgICAgICUggC5NgGgSw%2FqWPn2GuMFYb%2BEWuOrw4%2FYrBGAMW%2F5YtRhQz3F%2FVha1dIjR0Uil2AihDtYDr%2BQAZygxb5yX39OZeCA&c=%7E3YCAkIC%2BgICAgICAgIC9AgCXnLILCNLEWVvD4A7RTE6e5VQHnL67RAf8ffGpOTFExGjxp2lIHt%2Fmy8diAzMQSsxIFwmdegBxI7oRrX98i6CA&t=expression&st=true) will work again:

```
(
  if 
    true 
  then 
    { foo: { a+: 1 }} 
  else 
    { foo: { b-: 1 }}
).foo.a+
```

As a matter of fact this requires adjustments in custom context providers (these _must_ implement the merging properly themselves, cf. https://github.com/nikku/lezer-feel/pull/41/commits/280258ade8f00b550be68db3d8d4b1a775b092dc).

Closes #19
