### PR TITLE
feat: support exponential notation for numbers

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -457,7 +457,7 @@ commaSep<Expr> {
   }
 
   number {
-    (digits ("." digits)? | "." digits)
+    (digits ("." digits)? | "." digits) ( ("e" | "E") ("+" | "-")? digits)?
   }
 
   backtickIdentifier[@dialect=camunda] {

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -22,6 +22,27 @@ Expressions(
   NumericLiteral
 )
 
+# Literals (number, exponential notation) { "top": "Expressions"}
+
+1.231e4;
+1.231e+4;
+1.231e-4;
+1.231E4;
+1.231E-4;
+1.231E-4;
+.13e-1
+
+==>
+
+Expressions(
+  NumericLiteral,
+  NumericLiteral,
+  NumericLiteral,
+  NumericLiteral,
+  NumericLiteral,
+  NumericLiteral,
+  NumericLiteral
+)
 
 # ArithmeticExpression { "top": "Expressions" }
 


### PR DESCRIPTION
Support `1.231e-4` and other variants of exponential notation, as specified in the DMN spec:

![image](https://github.com/user-attachments/assets/eae6d9a5-be53-405d-9466-30a9cfcd4f63)

