### PR TITLE
test: verify string literal with string escape sequence

### DIFF
--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -4,6 +4,7 @@
 true;
 false;
 "FOO";
+"escaped\ncharacter\u0009";
 -1220.12;
 .12;
 24;
@@ -15,6 +16,7 @@ Expressions(
   NumericLiteral,
   BooleanLiteral,
   BooleanLiteral,
+  StringLiteral,
   StringLiteral,
   NumericLiteral(ArithOp),
   NumericLiteral,


### PR DESCRIPTION
This test case verifies that escape sequences are parsed correctly.

### Which issue does this PR address?

Related to https://github.com/camunda/camunda-modeler/issues/5089
