### PR TITLE
Eagerly parse context keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.8.0
+
+* `FEAT`: improve parsing speed with large contexts ([#54](https://github.com/nikku/lezer-feel/pull/54))
+* `FEAT`: eagerly normalize context keys ([#54](https://github.com/nikku/lezer-feel/pull/54))
+
 ## 1.7.1
 
 * `FIX`: require closing `"` on string literals ([#52](https://github.com/nikku/lezer-feel/pull/52))

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -8,6 +8,10 @@ export function normalizeContextKey(
   string
 ) : string;
 
+export function normalizeContextKeys<T>(
+  T
+) : T;
+
 export class VariableContext {
 
   value: any;

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,6 @@ export * from './parser.js';
 export {
   trackVariables,
   normalizeContextKey,
+  normalizeContextKeys,
   VariableContext
 } from './tokens.js';

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -738,7 +738,7 @@ class Variables {
   }
 
   contextKeys() {
-    return this.context.getKeys().map(normalizeContextKey);
+    return this.context.getKeys();
   }
 
   get path() {
@@ -753,17 +753,7 @@ class Variables {
    */
   get(variable) {
 
-    const names = [ variable, variable && normalizeContextKey(variable) ];
-
-    const contextKey = this.context.getKeys().find(
-      key => names.includes(normalizeContextKey(key))
-    );
-
-    if (typeof contextKey === 'undefined') {
-      return undefined;
-    }
-
-    const val = this.context.get(contextKey);
+    const val = this.context.get(variable);
 
     if (val instanceof ValueProducer) {
       return val.get(this);
@@ -828,7 +818,7 @@ class Variables {
       throw Error('no tokens to declare name');
     }
 
-    const variableName = this.tokens.join(' ');
+    const variableName = normalizeContextKey(this.tokens.join(' '));
 
     LOG_VARS && console.log('[%s] declareName <%s>', this.path, variableName);
 
@@ -852,7 +842,7 @@ class Variables {
 
     LOG_VARS && console.log('[%s] define <%s=%s>', this.path, name, value);
 
-    const context = this.context.set(name, value);
+    const context = this.context.set(normalizeContextKey(name), value);
 
     return this.assign({
       context
@@ -938,7 +928,39 @@ class Variables {
  * @return { string } normalizedName
  */
 export function normalizeContextKey(name) {
-  return name.replace(/\s*([./\-'+]|\*\*?)\s*/g, ' $1 ').replace(/\s{2,}/g, ' ').trim();
+  return name && name.replace(/\s*([./\-'+]|\*\*?)\s*/g, ' $1 ').replace(/\s{2,}/g, ' ').trim();
+}
+
+const nativeToString = Object.prototype.toString;
+
+export function isArray(obj) {
+  return nativeToString.call(obj) === '[object Array]';
+}
+
+export function isObject(obj) {
+  return nativeToString.call(obj) === '[object Object]';
+}
+
+/**
+ * @param {any} context
+ *
+ * @return {Object}
+ */
+export function normalizeContextKeys(context) {
+
+  if (isArray(context)) {
+    return context.map(normalizeContextKeys);
+  }
+
+  if (isObject(context)) {
+    return Object.entries(context).reduce((normalized, [ key, value ]) => {
+      normalized[normalizeContextKey(key)] = normalizeContextKeys(value);
+
+      return normalized;
+    }, {});
+  }
+
+  return context;
 }
 
 /**
@@ -979,7 +1001,7 @@ function wrap(variables, scopeName, code) {
 export function trackVariables(context = {}, Context = VariableContext) {
 
   const start = Variables.of({
-    context: Context.of(context)
+    context: Context.of(normalizeContextKeys(context))
   });
 
   return new ContextTracker({
@@ -1086,7 +1108,7 @@ export function trackVariables(context = {}, Context = VariableContext) {
           {
             value: Context
               .of(variables.value)
-              .set(name?.computedValue(), value?.computedValue())
+              .set(normalizeContextKey(name?.computedValue()), value?.computedValue())
           }
         );
       }
@@ -1240,9 +1262,7 @@ function getContextValue(variables, args) {
   }
 
   return variables.assign({
-    value: [ normalizeContextKey(keyValue), keyValue ].reduce((value, keyValue) => {
-      return contextValue.get(keyValue) || value;
-    }, null)
+    value: contextValue.get(normalizeContextKey(keyValue)) || null
   });
 }
 

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -298,6 +298,26 @@ Expression(
 )
 
 
+# Built in (get value, literal key, normalized) { "context": { "x": { "a+b": { "c   +": 1 } } } }
+
+get value(x, "a  +b").c+
+
+==>
+
+Expression(
+  PathExpression(
+    FunctionInvocation(
+      VariableName(...),"(",
+        PositionalParameters(
+          VariableName(...),StringLiteral
+        ),
+      ")"
+    ),
+    VariableName(...)
+  )
+)
+
+
 # Built in (get value, literal key, named args) { "context": { "x": { "a+b": { "c+": 1 } } } }
 
 get value(key: "a+b", m: x).c+;

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,7 +1,8 @@
 import {
   parser,
   trackVariables,
-  normalizeContextKey
+  normalizeContextKey,
+  normalizeContextKeys
 } from 'lezer-feel';
 
 import {
@@ -96,7 +97,7 @@ describe('lezer-feel', function() {
     // given
     const context = {};
 
-    for (var i = 0; i < 1000; i++) {
+    for (let i = 0; i < 1000; i++) {
       context[`key_${i}`] = i;
     }
 
@@ -117,7 +118,7 @@ describe('lezer-feel', function() {
     // given
     const context = {};
 
-    for (var i = 0; i < 1000; i++) {
+    for (let i = 0; i < 1000; i++) {
       context[`key_${i}`] = i;
     }
 
@@ -147,6 +148,54 @@ describe('lezer-feel', function() {
       expect(normalizeContextKey('a**\'s')).to.eql('a ** \' s');
 
       expect(normalizeContextKey('a***')).to.eql('a ** *');
+
+    });
+
+  });
+
+
+  describe('normalizeContextKeys', function() {
+
+    it('should normalize context', function() {
+
+      // given
+      const date = new Date();
+
+      expect(normalizeContextKeys({
+        'A+B  C': {
+          'A\'111+B  C': {
+            'a**\'s': 10,
+            bar: 100,
+            woop: true,
+            wap: false,
+            arr: [ 1, 'two', {
+              'a***': 10
+            }, [ [ [ {
+              'c++': 10
+            } ] ] ] ]
+          },
+          'foo': undefined,
+          'bar': null,
+          'd': date
+        }
+      })).to.eql({
+        'A + B C': {
+          'A \' 111 + B C': {
+            'a ** \' s': 10,
+            'bar': 100,
+            'woop': true,
+            wap: false,
+            arr: [ 1, 'two', {
+              'a ** *': 10
+            }, [ [ [ {
+              'c + +': 10
+            } ] ] ] ]
+          },
+          'foo': undefined,
+          'bar': null,
+          'd': date
+        }
+      });
 
     });
 

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -72,6 +72,70 @@ describe('lezer-feel', function() {
   });
 
 
+  it('should parse with small context', function() {
+
+    // given
+    const tracker = trackVariables({
+      a: 10,
+      b: 30,
+      'c + d': 10
+    });
+
+    // when
+    const configuredParser = parser.configure({
+      contextTracker: tracker
+    });
+
+    // then
+    configuredParser.parse('a + b + c+d');
+  });
+
+
+  it('should parse with large context', function() {
+
+    // given
+    const context = {};
+
+    for (var i = 0; i < 1000; i++) {
+      context[`key_${i}`] = i;
+    }
+
+    const tracker = trackVariables(context);
+
+    // when
+    const configuredParser = parser.configure({
+      contextTracker: tracker
+    });
+
+    // then
+    configuredParser.parse('key_191 + key_999');
+  });
+
+
+  it('should allow re-use of context tracker', function() {
+
+    // given
+    const context = {};
+
+    for (var i = 0; i < 1000; i++) {
+      context[`key_${i}`] = i;
+    }
+
+    const tracker = trackVariables(context);
+
+    // when
+    const configuredParser = parser.configure({
+      contextTracker: tracker
+    });
+
+    // then
+    configuredParser.parse('key_191 + key_999');
+
+    // and also
+    configuredParser.parse('key_2 + key_1');
+  });
+
+
   describe('normalizeContextKey', function() {
 
     it('should normalize string', function() {


### PR DESCRIPTION
### What is inside

* Speed up FEEL evaluation by eagerly normalizing context keys

Full details on this contribution [here](https://github.com/nikku/lezer-feel/pull/54#pullrequestreview-3114880242).

----

For the whole test suite, the invocations of `normalizeContextKey` change:

| | `normalizeContextKey` invocations |
|:---|---:|
|Before|43000|
|After|3000|

---

Related to https://github.com/nikku/lezer-feel/issues/59