### PR TITLE
Revert eager normalization of context keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.8.1
+
+_Revert of `v1.8.0`, as it broke custom contexts._
+
 ## 1.8.0
 
 * `FEAT`: improve parsing speed with large contexts ([#54](https://github.com/nikku/lezer-feel/pull/54))

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -8,10 +8,6 @@ export function normalizeContextKey(
   string
 ) : string;
 
-export function normalizeContextKeys<T>(
-  T
-) : T;
-
 export class VariableContext {
 
   value: any;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,5 @@ export * from './parser.js';
 export {
   trackVariables,
   normalizeContextKey,
-  normalizeContextKeys,
   VariableContext
 } from './tokens.js';

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -298,26 +298,6 @@ Expression(
 )
 
 
-# Built in (get value, literal key, normalized) { "context": { "x": { "a+b": { "c   +": 1 } } } }
-
-get value(x, "a  +b").c+
-
-==>
-
-Expression(
-  PathExpression(
-    FunctionInvocation(
-      VariableName(...),"(",
-        PositionalParameters(
-          VariableName(...),StringLiteral
-        ),
-      ")"
-    ),
-    VariableName(...)
-  )
-)
-
-
 # Built in (get value, literal key, named args) { "context": { "x": { "a+b": { "c+": 1 } } } }
 
 get value(key: "a+b", m: x).c+;

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -8,6 +8,11 @@ import {
   expect
 } from 'chai';
 
+import {
+  EntriesContext,
+  toEntriesContextValue
+} from './custom-context.js';
+
 
 describe('lezer-feel', function() {
 
@@ -133,6 +138,33 @@ describe('lezer-feel', function() {
 
     // and also
     configuredParser.parse('key_2 + key_1');
+  });
+
+
+  describe('custom entries context', function() {
+
+    it('should ignore external meta-data', function() {
+
+      // given
+      const context = toEntriesContextValue({
+        foo: 'BAR'
+      });
+
+      // we don't care about meta-data
+      context.meta = {};
+      context.meta.meta = context.meta;
+
+      const tracker = trackVariables(context, EntriesContext);
+
+      // when
+      const configuredParser = parser.configure({
+        contextTracker: tracker
+      });
+
+      // then
+      configuredParser.parse('foo');
+    });
+
   });
 
 

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,8 +1,7 @@
 import {
   parser,
   trackVariables,
-  normalizeContextKey,
-  normalizeContextKeys
+  normalizeContextKey
 } from 'lezer-feel';
 
 import {
@@ -97,7 +96,7 @@ describe('lezer-feel', function() {
     // given
     const context = {};
 
-    for (let i = 0; i < 1000; i++) {
+    for (var i = 0; i < 1000; i++) {
       context[`key_${i}`] = i;
     }
 
@@ -118,7 +117,7 @@ describe('lezer-feel', function() {
     // given
     const context = {};
 
-    for (let i = 0; i < 1000; i++) {
+    for (var i = 0; i < 1000; i++) {
       context[`key_${i}`] = i;
     }
 
@@ -148,54 +147,6 @@ describe('lezer-feel', function() {
       expect(normalizeContextKey('a**\'s')).to.eql('a ** \' s');
 
       expect(normalizeContextKey('a***')).to.eql('a ** *');
-
-    });
-
-  });
-
-
-  describe('normalizeContextKeys', function() {
-
-    it('should normalize context', function() {
-
-      // given
-      const date = new Date();
-
-      expect(normalizeContextKeys({
-        'A+B  C': {
-          'A\'111+B  C': {
-            'a**\'s': 10,
-            bar: 100,
-            woop: true,
-            wap: false,
-            arr: [ 1, 'two', {
-              'a***': 10
-            }, [ [ [ {
-              'c++': 10
-            } ] ] ] ]
-          },
-          'foo': undefined,
-          'bar': null,
-          'd': date
-        }
-      })).to.eql({
-        'A + B C': {
-          'A \' 111 + B C': {
-            'a ** \' s': 10,
-            'bar': 100,
-            'woop': true,
-            wap: false,
-            arr: [ 1, 'two', {
-              'a ** *': 10
-            }, [ [ [ {
-              'c + +': 10
-            } ] ] ] ]
-          },
-          'foo': undefined,
-          'bar': null,
-          'd': date
-        }
-      });
 
     });
 


### PR DESCRIPTION
### Which issue does this PR address?

https://github.com/nikku/lezer-feel/pull/54 introduced averse effects on custom context implementations, which may contain nested keys, cf. [test case](https://github.com/nikku/lezer-feel/commit/b2ef792eca95b834e8912f26a7ebc5aca5e97610).

Any implementation that eagerly normalizes the context must properly account for such custom context values, or we will break user-land.


----

The [attached test case](https://github.com/nikku/lezer-feel/pull/55/commits/b2ef792eca95b834e8912f26a7ebc5aca5e97610) runs into an infinite loop, when executed against `v1.8.0`:

```
  1) lezer-feel
       custom entries context
         should ignore external meta-data:
     RangeError: Maximum call stack size exceeded
      at String.replace (<anonymous>)
      at normalizeContextKey (file://projects/lezer-feel/src/tokens.js:931:23)
      at file://projects/lezer-feel/src/tokens.js:957:18
      at Array.reduce (<anonymous>)
      at normalizeContextKeys (file://projects/lezer-feel/src/tokens.js:956:36)
      at file://projects/lezer-feel/src/tokens.js:957:46
      at Array.reduce (<anonymous>)
      at normalizeContextKeys (file://projects/lezer-feel/src/tokens.js:956:36)
      at file://projects/lezer-feel/src/tokens.js:957:46
      at Array.reduce (<anonymous>)
      at normalizeContextKeys (file://projects/lezer-feel/src/tokens.js:956:36)
      at file://projects/lezer-feel/src/tokens.js:957:46
      at Array.reduce (<anonymous>)
      at normalizeContextKeys (file://projects/lezer-feel/src/tokens.js:956:36)
      at file://projects/lezer-feel/src/tokens.js:957:46
      at Array.reduce (<anonymous>)
```