### PR TITLE
Support multiline strings in `camunda` dialect

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -390,7 +390,7 @@ NumericLiteral {
 }
 
 StringLiteral {
-  string
+  multilineString | string
 }
 
 BooleanLiteral {
@@ -453,8 +453,14 @@ commaSep<Expr> {
   }
 
   string {
-    '"' (![\\\n"] | "\\" _)* '"'
+    '"' (![\n"] | "\\" _)* '"'
   }
+
+  multilineString[@dialect=camunda] {
+    '"' (!["] | "\\" _)* '"'
+  }
+
+  @precedence { multilineString, string }
 
   number {
     (digits ("." digits)? | "." digits) ( ("e" | "E") ("+" | "-")? digits)?

--- a/test/camunda.txt
+++ b/test/camunda.txt
@@ -11,3 +11,13 @@ Expressions(
   PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
   PathExpression(VariableName(...), VariableName(BacktickIdentifier(...)))
 )
+
+
+# String Literal (multi-line) { "dialect": "camunda" }
+
+"foo
+baz"
+
+==>
+
+Expression(StringLiteral)

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -46,17 +46,35 @@ Expressions(
   NumericLiteral
 )
 
-# String Literal (error) { "top": "Expressions" }
+# String Literal (escaped quotes)
 
-"test;
-"test\n;
+"test\""
 
 ==>
 
-Expressions(
-  ⚠,VariableName(Identifier),
-  ⚠,VariableName(Identifier,⚠,Identifier),⚠
+Expression(StringLiteral)
+
+
+# String Literal (error, no closing quotes)
+
+"test
+
+==>
+
+Expression(
+  ⚠,VariableName(Identifier)
 )
+
+
+# String Literal (error, newline)
+
+"test
+"
+
+==>
+
+Expression(⚠,VariableName(Identifier),⚠)
+
 
 # ArithmeticExpression { "top": "Expressions" }
 

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -24,7 +24,7 @@ Expressions(
   NumericLiteral
 )
 
-# Literals (number, exponential notation) { "top": "Expressions"}
+# Literals (number, exponential notation) { "top": "Expressions" }
 
 1.231e4;
 1.231e+4;


### PR DESCRIPTION
Camunda dialect supports multi-line strings ([ref](https://camunda.github.io/feel-scala/docs/playground/?expression=IkFCQwpERUYi&context=e30%3D&expression-type=expression)). This PR adds support for it.