### PR TITLE
fix: allow line breaks in backtick identifiers

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -467,7 +467,7 @@ commaSep<Expr> {
   }
 
   backtickIdentifier[@dialect=camunda] {
-    "`" (![\\\n`] | "\\" _)* "`"
+    "`" (![`] | "\\" _)* "`"
   }
 
   @precedence { BlockComment, LineComment, divide }

--- a/test/camunda.txt
+++ b/test/camunda.txt
@@ -3,13 +3,18 @@
 `foo`;
 foo.`bar`;
 foo.`bar-baz`;
+`foo
+baz`;
+`foo\``
 
 ==>
 
 Expressions(
   VariableName(BacktickIdentifier(...)),
   PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
-  PathExpression(VariableName(...), VariableName(BacktickIdentifier(...)))
+  PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
+  VariableName(BacktickIdentifier(...)),
+  VariableName(BacktickIdentifier(...))
 )
 
 


### PR DESCRIPTION
Camunda dialect supports line breaks in backtick identifiers ([ref](https://camunda.github.io/feel-scala/docs/playground/?expression=YEFCQwpERUZg&context=ewogICJBQkNcbkRFRiI6IDEwCn0%3D&expression-type=expression)). This PR adds support for it.