### PR TITLE
Expand tests for large feel contexts to use names with multiple tokens

### DIFF
--- a/test/test-index.js
+++ b/test/test-index.js
@@ -303,7 +303,16 @@ describe('lezer-feel', function() {
 
       // given
       const context = toEntriesContextValue({
-        foo: 'BAR'
+        'foo +  100': {
+          'baa---': 'BAR'
+        },
+        woop: 'WAAP',
+        yup: 'YUP',
+        other: {
+          nested: {
+            thing: 0
+          }
+        }
       });
 
       // we don't care about meta-data
@@ -318,7 +327,7 @@ describe('lezer-feel', function() {
       });
 
       // then
-      configuredParser.parse('foo');
+      configuredParser.parse('foo +  100.baa--- + woop + yup + other.nested.thing');
     });
 
   });


### PR DESCRIPTION
### What is inside

No change in behavior yet, just showing the obvious reported in #59, in more contexts:

<img width="494" height="394" alt="image" src="https://github.com/user-attachments/assets/c57df5c2-7934-4973-beba-151e43ce3e9f" />
