### PR TITLE
feat: preserve externally passed list types

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -622,24 +622,29 @@ export class VariableContext {
    */
   static __merge(context, other) {
 
-    const merged = Object.assign({}, this.__unwrap(context));
+    const merged = {};
 
-    for (const [ key, value ] of Object.entries(this.__unwrap(other))) {
-      if (value instanceof ValueProducer) {
+    const contexts = [ context, other ].flat();
 
-        // keep value producers in tact
+    for (const ctx of contexts) {
+
+      for (const [ key, value ] of Object.entries(this.__unwrap(ctx))) {
+        if (value instanceof ValueProducer) {
+
+          // keep value producers in tact
+          merged[key] = value;
+          continue;
+        }
+
+        if (has(merged, key)) {
+
+          // deep merge nested contexts
+          merged[key] = this.__merge(merged[key], value);
+          continue;
+        }
+
         merged[key] = value;
-        continue;
       }
-
-      if (has(merged, key)) {
-
-        // deep merge nested contexts
-        merged[key] = this.__merge(merged[key], value);
-        continue;
-      }
-
-      merged[key] = value;
     }
 
     return merged;

--- a/test/custom-context.js
+++ b/test/custom-context.js
@@ -25,7 +25,7 @@ export class EntriesContext extends VariableContext {
         continue;
       }
 
-      entries[key] = EntriesContext.of(entry);
+      entries[key] = Array.isArray(entry) ? EntriesContext.of(...entry) : EntriesContext.of(entry);
     }
   }
 
@@ -118,6 +118,10 @@ export class EntriesContext extends VariableContext {
 
 
 export function toEntriesContextValue(context) {
+
+  if (Array.isArray(context)) {
+    return context.map(toEntriesContextValue);
+  }
 
   return context && Object.keys(context).reduce((result, key) => {
     const value = context[key];

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -908,6 +908,18 @@ Expression(
   )
 )
 
+
+# List (union type, external) { "context": { "list": [ { "a+": 1 }, { "b+": 1 } ] } }
+
+list.b+
+
+==>
+
+Expression(
+  PathExpression(VariableName(...),VariableName(...))
+)
+
+
 # Interval / List (error) { "top": "Expressions" }
 
 [a;

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -48,46 +48,93 @@ describe('custom context', function() {
   });
 
 
-  it('should create value via utility', function() {
+  describe('should create value via utility', function() {
 
-    // given
-    const contextValue = toEntriesContextValue({
-      a: {
-        ab: 10
-      }
-    });
+    it('context', function() {
 
-    // assume
-    expect(contextValue).to.eql({
-      entries: {
+      // given
+      const contextValue = toEntriesContextValue({
         a: {
-          entries: {
-            ab: 10
+          ab: 10
+        }
+      });
+
+      // assume
+      expect(contextValue).to.eql({
+        entries: {
+          a: {
+            entries: {
+              ab: 10
+            }
           }
         }
-      }
-    });
+      });
 
-    // when
-    const context = EntriesContext.of(contextValue);
+      // when
+      const context = EntriesContext.of(contextValue);
 
-    // then
-    expect(context.value).to.eql({
-      entries: {
-        a: {
-          value: {
-            entries: {
-              ab: {
-                value: {
-                  atomicValue: 10,
-                  entries: {}
+      // then
+      expect(context.value).to.eql({
+        entries: {
+          a: {
+            value: {
+              entries: {
+                ab: {
+                  value: {
+                    atomicValue: 10,
+                    entries: {}
+                  }
                 }
               }
             }
           }
         }
-      }
+      });
     });
+
+
+    it('list', function() {
+
+      // given
+      const contextValue = toEntriesContextValue({
+        a: [
+          { b: 1 },
+          { b: 2 }
+        ]
+      });
+
+      // assume
+      expect(contextValue).to.eql({
+        entries: {
+          a: [
+            { entries: { b: 1 } },
+            { entries: { b: 2 } }
+          ]
+        }
+      });
+
+      // when
+      const context = EntriesContext.of(contextValue);
+
+      // then
+      expect(context.value).to.eql({
+        entries: {
+          a: {
+            value: {
+              entries: {
+                b: {
+                  value: {
+                    atomicValue: 2,
+                    entries: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
   });
 
 
@@ -255,6 +302,60 @@ describe('custom context', function() {
     });
 
 
+    it('list (from context, path)', function() {
+
+      // given
+      const context = {
+        list: [ 1, null, { 'a+': 1 }, { 'b+': 2 } ]
+      };
+
+      // when
+      const shape = computedValue(`
+        list.a+
+      `, context);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: 1,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('list (from context, filter, path)', function() {
+
+      // given
+      const context = {
+        list: [
+          { a: { b: 1 } },
+          { a: { b: 2 } },
+          { a: { b: 3 } }
+        ]
+      };
+
+      // when
+      const shape = computedValue(`
+        list[1].a
+      `, context);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          entries: {
+            b: {
+              value: {
+                atomicValue: 3,
+                entries: {}
+              }
+            }
+          }
+        }
+      });
+    });
+
+
     it('context', function() {
 
       // when
@@ -282,6 +383,60 @@ describe('custom context', function() {
               }
             }
           }
+        }
+      });
+    });
+
+
+    it('context (from context)', function() {
+
+      // given
+      const context = {
+        'd+': {
+          result: 100
+        }
+      };
+
+      // when
+      const shape = computedValue(`
+        d+.result
+      `, context);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: 100,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('context (from context, path, filter)', function() {
+
+      // given
+      const context = {
+        a: {
+          'b+': {
+            c: {
+              d: [
+                { e: 1 },
+                { e: 2 }
+              ]
+            }
+          }
+        }
+      };
+
+      // when
+      const shape = computedValue(`
+        a.b+.c.d[1]
+      `, context);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          entries: { e: { value: { atomicValue: 2, entries: {} } } }
         }
       });
     });


### PR DESCRIPTION
### Which issue does this PR address?

On top of #70 this PR ensures that we recognize types from externally passed lists:

```
# List (union type, external) { "context": { "list": [ { "a+": 1 }, { "b+": 1 } ] } }

list.b+

==>

Expression(
  PathExpression(VariableName(...),VariableName(...))
)
```

Today, [those are not recognized](https://nikku.github.io/feel-playground/?e=list%5B3%5D.c%2B&c=%7E3YCAkIDFgICAgICAgIC9AgCXnK0NSei7h%2B6C3z%2FDTaancg%2FxlkxjNnZeQdygnM09I%2BSSVDeRnPRw5KtOX3w0HoA%3D&t=expression&st=false).


----

Draft, because the alternative is that we improve typing of filter expressions `list[1]`, and keep existing shape of externally passed list as an object with named (`1`, `2`, ...) properties.