### PR TITLE
fix: correctly compute `atomicValue` for falsy values

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,6 +1,6 @@
 /* global process */
 
-import { has } from 'min-dash';
+import { has, isNil } from 'min-dash';
 
 import {
   insertSemi,
@@ -649,7 +649,8 @@ export class VariableContext {
    * @returns {Boolean}
    */
   static isAtomic(value) {
-    return !value ||
+    return value === null ||
+          value === undefined ||
           value instanceof this ||
           value instanceof ValueProducer ||
           typeof value !== 'object';
@@ -848,7 +849,7 @@ class Variables {
         return null;
       }
 
-      if (scope.value) {
+      if (!isNil(scope.value)) {
         return scope.value;
       }
     }
@@ -1098,7 +1099,7 @@ function wrap(variables, scopeName, code) {
   const valuePart = parts[Math.max(1, parts.length - 1)];
 
   const name = namePart?.computedValue();
-  const value = valuePart?.computedValue() || null;
+  const value = valuePart?.computedValue() ?? null;
 
   return variables
     .assign({

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -213,7 +213,7 @@ describe('custom context', function() {
     }
 
 
-    it('atomic value', function() {
+    it('atomic value (number)', function() {
 
       // then
       const shape = computedValue(`
@@ -222,6 +222,94 @@ describe('custom context', function() {
 
       // then
       expect(shape).to.eql(1);
+    });
+
+
+    it('atomic value (string)', function() {
+
+      // then
+      const shape = computedValue(`
+        "foo"
+      `);
+
+      // then
+      expect(shape).to.eql('foo');
+    });
+
+
+    it('atomic value (boolean)', function() {
+
+      // then
+      const shapeTrue = computedValue(`
+        true
+      `);
+      const shapeFalse = computedValue(`
+        false
+      `);
+
+      // then
+      expect(shapeTrue).to.eql(true);
+      expect(shapeFalse).to.eql(false);
+    });
+
+
+    it('boolean values in context', function() {
+
+      // when
+      const shape = computedValue(`
+        { booleanFalse: false, booleanTrue: true }
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            booleanFalse: {
+              value: {
+                atomicValue: false,
+                entries: {}
+              }
+            },
+            booleanTrue: {
+              value: {
+                atomicValue: true,
+                entries: {}
+              }
+            }
+          }
+        }
+      });
+    });
+
+
+    it('falsy values in context', function() {
+
+      // when
+      const shape = computedValue(`
+        { zero: 0, emptyString: "" }
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            zero: {
+              value: {
+                atomicValue: 0,
+                entries: {}
+              }
+            },
+            emptyString: {
+              value: {
+                atomicValue: '',
+                entries: {}
+              }
+            }
+          }
+        }
+      });
     });
 
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/variable-resolver/issues/52

### Proposed Changes

Fix how `atomicValue` is computed for falsy values (`false` or empty string).

If we check for `!value`, the atomic value is not computed for falsy values, e.g. `false` which is a valid boolean value.

Additionally, `||` operator also doesn't pick up falsy values.