### PR TITLE
feat: allow iteration context in quantified expression

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -96,7 +96,7 @@ QuantifiedInExpressions[@name=InExpressions] {
 }
 
 QuantifiedInExpression[@name=InExpression] {
-  inExpression<expression>
+  inExpression<IterationContext>
 }
 
 QuantifiedExpression {

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -1154,7 +1154,7 @@ satisfies
 Expression(
   QuantifiedExpression(
     every,InExpressions(
-      InExpression(Name(...),in,List("[","]"))
+      InExpression(Name(...),in,IterationContext(List("[","]")))
     ), satisfies, PathExpression(
       VariableName(...),
       VariableName(...)
@@ -1175,9 +1175,9 @@ satisfies
 Expression(
   QuantifiedExpression(
     every,InExpressions(
-      InExpression(Name(...),in,List("[",
+      InExpression(Name(...),in,IterationContext(List("[",
         Context("{",ContextEntry(Key(Name(...)),NumericLiteral),"}"),
-      "]"))
+      "]")))
     ),satisfies,
     PathExpression(
       VariableName(...),
@@ -1195,6 +1195,25 @@ every a in b satisfies
 
 Expression(
   QuantifiedExpression(every,InExpressions(...),satisfies,⚠),
+)
+
+
+# QuantifiedExpression (iteration context)
+
+some i in 1..10 satisfies i > 5
+
+==>
+
+Expression(
+  QuantifiedExpression(
+    some,InExpressions(
+      InExpression(Name(Identifier),in,IterationContext(
+        NumericLiteral,
+        NumericLiteral
+      ))
+    ),satisfies,
+    Comparison(...)
+  )
 )
 
 
@@ -2290,8 +2309,8 @@ every a a in b, dd in [] satisfies a a < dd - c
 Expression(
   QuantifiedExpression(
     every,InExpressions(
-      InExpression(Name(...),in,VariableName(...)),
-      InExpression(Name(...),in,List("[","]"))
+      InExpression(Name(...),in,IterationContext(VariableName(...))),
+      InExpression(Name(...),in,IterationContext(List("[","]")))
     ),satisfies,Comparison(
       VariableName(...),CompareOp,ArithmeticExpression(
         VariableName(...),ArithOp,VariableName(...)


### PR DESCRIPTION
Related to https://github.com/camunda/camunda/issues/40304

### Proposed Changes

This adds support for iteration context in quantified expressions to get us ready for DMN 1.7 support: https://github.com/camunda/camunda/issues/40304#issuecomment-3882941504
It's already supported in Camunda FEEL engine (feel-scala).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
