### PR TITLE
fix: unescape FEEL string literal escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.3.1
+
+* `FIX`: unescape escape sequences in FEEL string literals ([#81](https://github.com/nikku/lezer-feel/pull/81))
+
 ## 2.3.0
 
 * `FEAT`: support `IterationContext` in `QuantifiedExpression` ([#79](https://github.com/nikku/lezer-feel/pull/79))

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1288,7 +1288,7 @@ export function trackVariables(context = {}, Context = VariableContext) {
       if (
         term === StringLiteral
       ) {
-        return variables.literal(code.replace(/^"|"$/g, ''));
+        return variables.literal(code.replace(/^"|"$/g, '').replace(/\\(["\\])/g, '$1'));
       }
 
       if (term === BooleanLiteral) {

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -184,7 +184,7 @@ describe('custom context', function() {
 
   describe('should allow retrival of context value', function() {
 
-    function computedValue(expression, context = {}) {
+    function computedValue(expression, context = {}, dialect = 'feel') {
 
       const contextTracker = trackVariables(toEntriesContextValue(context), EntriesContext);
 
@@ -203,6 +203,7 @@ describe('custom context', function() {
       });
 
       const contextualParser = parser.configure({
+        dialect,
         contextTracker: customContextTracker,
         strict: true
       });
@@ -234,6 +235,66 @@ describe('custom context', function() {
 
       // then
       expect(shape).to.eql('foo');
+    });
+
+
+    it('atomic value (string with escaped quotes)', function() {
+
+      // when
+      const shape = computedValue(`
+        "\\"YES\\"\\"\\""
+      `);
+
+      // then
+      expect(shape).to.eql('"YES"""');
+    });
+
+
+    it('atomic value (string with escaped backslash)', function() {
+
+      // when
+      const shape = computedValue(`
+        "hello\\\\world"
+      `);
+
+      // then
+      expect(shape).to.eql('hello\\world');
+    });
+
+
+    it('atomic value (string with mixed escapes)', function() {
+
+      // when
+      const shape = computedValue(`
+        "hello\\"\\world\\"\\"
+      `);
+
+      // then
+      expect(shape).to.eql('hello"\\world"\\');
+    });
+
+
+    it('atomic value (string with escaped newline)', function() {
+
+      // when
+      const shape = computedValue(`
+        "hello\\nworld"
+      `);
+
+      // then
+      expect(shape).to.eql('hello\\nworld');
+    });
+
+
+    it('atomic value (multi-line string, camunda)', function() {
+
+      // when
+      const shape = computedValue(`
+        "hello\nworld"
+      `, {}, 'camunda');
+
+      // then
+      expect(shape).to.eql('hello\nworld');
     });
 
 


### PR DESCRIPTION
Related to bpmn-io/variable-resolver#88

### Proposed Changes

This pull request aims to "unescape" escape sequences for string literals so that upstreams do not double-serialize/encode string literals.