### PR TITLE
fix: correct backslash handling in string and identifier tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: correct backslash handling in string and identifier tokens ([#83](https://github.com/nikku/lezer-feel/pull/83))
+
 ## 2.3.1
 
 * `FIX`: unescape escape sequences in FEEL string literals ([#81](https://github.com/nikku/lezer-feel/pull/81))

--- a/package-lock.json
+++ b/package-lock.json
@@ -818,7 +818,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1669,7 +1668,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3979,7 +3977,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -453,11 +453,11 @@ commaSep<Expr> {
   }
 
   string {
-    '"' (![\n"] | "\\" _)* '"'
+    '"' (![\n"\\] | "\\" _)* '"'
   }
 
   multilineString[@dialect=camunda] {
-    '"' (!["] | "\\" _)* '"'
+    '"' (!["\\] | "\\" _)* '"'
   }
 
   @precedence { multilineString, string }
@@ -467,7 +467,7 @@ commaSep<Expr> {
   }
 
   backtickIdentifier[@dialect=camunda] {
-    "`" (![`] | "\\" _)* "`"
+    "`" (![`])* "`"
   }
 
   @precedence { BlockComment, LineComment, divide }

--- a/test/camunda.txt
+++ b/test/camunda.txt
@@ -4,8 +4,7 @@
 foo.`bar`;
 foo.`bar-baz`;
 `foo
-baz`;
-`foo\``
+baz`
 
 ==>
 
@@ -13,9 +12,35 @@ Expressions(
   VariableName(BacktickIdentifier(...)),
   PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
   PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
-  VariableName(BacktickIdentifier(...)),
   VariableName(BacktickIdentifier(...))
 )
+
+
+# BacktickIdentifier (backslash is literal) { "dialect": "camunda" }
+
+`foo\bar`
+
+==>
+
+Expression(VariableName(BacktickIdentifier(...)))
+
+
+# BacktickIdentifier (backslash at end) { "dialect": "camunda" }
+
+`foo\`
+
+==>
+
+Expression(VariableName(BacktickIdentifier(...)))
+
+
+# BacktickIdentifier (double backslash) { "dialect": "camunda" }
+
+`foo\\bar`
+
+==>
+
+Expression(VariableName(BacktickIdentifier(...)))
 
 
 # String Literal (multi-line) { "dialect": "camunda" }
@@ -26,3 +51,48 @@ baz"
 ==>
 
 Expression(StringLiteral)
+
+
+# String Literal (backslash) { "dialect": "camunda" }
+
+"\\"
+
+==>
+
+Expression(StringLiteral)
+
+
+# String Literal (backslash, double) { "dialect": "camunda" }
+
+"\\\\"
+
+==>
+
+Expression(StringLiteral)
+
+
+# String Literal (backslash, escaped quote) { "dialect": "camunda" }
+
+"\\\"" 
+
+==>
+
+Expression(StringLiteral)
+
+
+# ArithmeticExpression (string concatenation, backslash) { "dialect": "camunda" }
+
+"\\" + "B"
+
+==>
+
+Expression(ArithmeticExpression(StringLiteral,ArithOp,StringLiteral))
+
+
+# ArithmeticExpression (string concatenation, three parts with backslash) { "dialect": "camunda" }
+
+"A" + "\\" + "B"
+
+==>
+
+Expression(ArithmeticExpression(ArithmeticExpression(StringLiteral,ArithOp,StringLiteral),ArithOp,StringLiteral))

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -2781,6 +2781,51 @@ Expression(
 )
 
 
+# String Literal (backslash)
+
+"\\"
+
+==>
+
+Expression(StringLiteral)
+
+
+# String Literal (backslash, double)
+
+"\\\\"
+
+==>
+
+Expression(StringLiteral)
+
+
+# String Literal (backslash, escaped quote)
+
+"\\\"" 
+
+==>
+
+Expression(StringLiteral)
+
+
+# ArithmeticExpression (string concatenation, backslash)
+
+"\\" + "B"
+
+==>
+
+Expression(ArithmeticExpression(StringLiteral,ArithOp,StringLiteral))
+
+
+# ArithmeticExpression (string concatenation, three parts with backslash)
+
+"A" + "\\" + "B"
+
+==>
+
+Expression(ArithmeticExpression(ArithmeticExpression(StringLiteral,ArithOp,StringLiteral),ArithOp,StringLiteral))
+
+
 # Backtick escaped variables (Camunda) { "top": "Expressions", "dialect": "camunda" }
 
 `foo`;

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -266,7 +266,7 @@ describe('custom context', function() {
 
       // when
       const shape = computedValue(`
-        "hello\\"\\world\\"\\"
+        "hello\\"\\\\world\\"\\\\"
       `);
 
       // then


### PR DESCRIPTION
### Which issue does this PR address?

Related to https://github.com/camunda/camunda-modeler/issues/5844

This pull request aims to correct backslash handling in FEEL string and identifier tokens.

#### String and multiline string tokens

The `string` and `multilineString` token rules in `src/feel.grammar` used character class patterns like `(![\n"] | "\\" _)*` where the non-escape character class `![\n"]` excludes newlines and double quotes but does not exclude backslashes. Combined with the escape sequence pattern `"\\" _`, where `_` matches any character including closing delimiters, this causes the Lezer DFA tokenizer to misparse strings ending with an escaped backslash.

For example, when parsing `"\\" + "B"`:

1. The tokenizer reads `\\` as the start of an escape sequence
2. `_` greedily consumes⁰ the closing `"` as the escaped character
3. The `StringLiteral` extends through `+ "`, swallowing the operator and the next opening quote
4. This produces a parse error: "Unparsable FEEL expression"

The fix excludes `\` from the non-escape character class in both token rules, ensuring backslashes are only matched through the explicit escape sequence pattern `"\\" _`.

#### Backtick identifier tokens

The `backtickIdentifier` token rule used the same escape sequence pattern `` (![`] | "\\" _)* `` implying support for escape sequences inside backtick identifiers. However, [FEEL-Scala treats backslashes as literal characters](https://github.com/camunda/feel-scala/blob/main/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala#L176) inside backtick identifiers; there are no escape sequences and no way to include a backtick within the identifier.

The fix removes the escape sequence branch entirely, changing the rule to `` (![`])* ``, aligning with FEEL-Scala behavior.

**Before** (screenshots without changes from this branch)

<img width="562" alt="image" src="https://github.com/user-attachments/assets/7944be2c-443f-4450-97e7-1ece4037f7b0" />

<img width="562" alt="from feel-playground" src="https://github.com/user-attachments/assets/97f4060f-decd-4f46-acae-b92c26be4a57" />

https://nikku.github.io/feel-playground/?e=%22A%22+%2B+%22%5C%5C%5C%5C%22+%2B+%22B%22&c=%7B%7D&t=expression&st=true

**After** (screenshots linked with this branch)

<img width="562" alt="image" src="https://github.com/user-attachments/assets/ad22d456-7148-4d1d-8dc4-f3777642733d" />

<img width="562" alt="image" src="https://github.com/user-attachments/assets/0bf677dc-63b8-4726-91f3-2580ad0f9e8f" />

⁰ The greedy consumption can be observed in the screenshot below. As `"\\\\" + "C"` is (wrongly) unparsable FEEL expression due to greedy consumption of escape sequence, `"\\\\"" + "C"` parses (even though it is wrong) due to the additional `"` in the first operand closing the first string. Another (false-positive) parse-able sample: `"\\" + " + "\\"`

<img width="562" alt="image" src="https://github.com/user-attachments/assets/b049e572-0e17-4125-9838-67b2e00d7094" />