### PR TITLE
fix: do not leak function arguments as computed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: do not leak function arguments as computed values ([#84](https://github.com/nikku/lezer-feel/pull/84), [camunda/camunda-modeler#5744](https://github.com/camunda/camunda-modeler/issues/5744))
+
 ## 2.3.2
 
 * `FIX`: correct backslash handling in string and identifier tokens ([#83](https://github.com/nikku/lezer-feel/pull/83))

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -659,7 +659,7 @@ export class VariableContext {
   /**
    * Takes any number of Contexts and merges them into a single context.
    *
-   * @param { ...VariableContext } contexts
+   * @param { ...(VariableContext | undefined) } contexts
    * @returns { VariableContext }
    */
   static of(...contexts) {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -856,7 +856,7 @@ class Variables {
   }
 
   /**
-   * Get or compute the context cache for fast retrival
+   * Get or compute the context cache for fast retrieval
    * of keys, prefixes and original mappings.
    *
    * @returns {ContextCache}
@@ -1166,6 +1166,10 @@ export function trackVariables(context = {}, Context = VariableContext) {
         // preserve type information through `get value(context, key)` utility
         if (name?.raw === 'get value') {
           variables = getContextValue(variables, args);
+        } else {
+          variables = variables.assign({
+            value: name?.computedValue() || Context.of(undefined)
+          });
         }
       }
 

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -182,7 +182,7 @@ describe('custom context', function() {
   });
 
 
-  describe('should allow retrival of context value', function() {
+  describe('should allow retrieval of context value', function() {
 
     function computedValue(expression, context = {}, dialect = 'feel') {
 
@@ -428,6 +428,176 @@ describe('custom context', function() {
               value: {
                 atomicValue: 10,
                 entries: {}
+              }
+            }
+          }
+        }
+      });
+    });
+
+
+    it('function invocation (single argument)', function() {
+
+      // when
+      const shape = computedValue(`
+        abs(-22)
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('function invocation (multiple arguments)', function() {
+
+      // when
+      const shape = computedValue(`
+        substring("foobar", 3)
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('function invocation (no arguments)', function() {
+
+      // when
+      const shape = computedValue(`
+        now()
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('function invocation (nested)', function() {
+
+      // when
+      const shape = computedValue(`
+        abs(round(-22.5))
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('function invocation (context-defined, preserves return shape)', function() {
+
+      // when
+      const shape = computedValue(`
+        {
+          a: function() { a+: { b-: 1 } },
+          b: a()
+        }.b
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            'a +': {
+              value: {
+                atomicValue: undefined,
+                entries: {
+                  'b -': {
+                    value: {
+                      atomicValue: 1,
+                      entries: {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+
+    it('function invocation (context-defined, nested unknown)', function() {
+
+      // when
+      const shape = computedValue(`
+        {
+          a: function() { a+: { b-: abs(x) } },
+          b: a()
+        }.b
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            'a +': {
+              value: {
+                atomicValue: undefined,
+                entries: {
+                  'b -': {
+                    value: {
+                      atomicValue: undefined,
+                      entries: {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+
+    it('function invocation (context-defined, nested unknown with provided context)', function() {
+
+      // when
+      const shape = computedValue(`
+        {
+          a: function() { a+: { b-: abs(x) } },
+          b: a()
+        }.b
+      `, { x: -5 });
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            'a +': {
+              value: {
+                atomicValue: undefined,
+                entries: {
+                  'b -': {
+                    value: {
+                      atomicValue: undefined,
+                      entries: {}
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
### Proposed changes

This pull request aims to stop leaking last operands of the function invocation for built-in functions while computing user-defined functions as much as possible.

A variable with value of `abs(round(-22.5))` used to leak `22.5` which was much misleading than being helpful. Marking unresolvable functions as `Context.of(undefined)` enables variable-resolver to preserve the FEEL expression to display them in the variable-outline.

**Before**

<img width="309" height="124" alt="image" src="https://github.com/user-attachments/assets/15029a3e-82ef-4532-99cc-e79b5c0aef0d" />


**After**

<img width="521" height="124" alt="image" src="https://github.com/user-attachments/assets/16bf3d99-f3df-4dfc-a5ec-3933e3e1b1eb" />

<br>
Note: The screenshots are from variable-outline using this branch and another branch I'm about to create in variable-resolver. 

### Which issue does this PR address?

Related to camunda/camunda-modeler#5744