### PR TITLE
Custom context variants

### DIFF
--- a/test/custom-context.js
+++ b/test/custom-context.js
@@ -7,6 +7,86 @@ import {
  * @typedef { { entries?: Record<string, any>, [key: string]: any } } EntriesContextValue
  */
 
+
+/**
+ * A context that holds multiple alternative shape variants,
+ * preserving distinct shapes instead of merging them.
+ */
+class UnionContext extends VariableContext {
+
+  /**
+   * @param { VariableContext[] } variants
+   */
+  constructor(variants) {
+    super({});
+    this.variants = variants;
+  }
+
+  /**
+   * Return all keys available across all variants.
+   *
+   * @returns {string[]}
+   */
+  getKeys() {
+    const allKeys = new Set();
+    for (const variant of this.variants) {
+      for (const key of variant.getKeys()) {
+        allKeys.add(key);
+      }
+    }
+    return [ ...allKeys ];
+  }
+
+  /**
+   * Return value for the given key, searching across all variants.
+   * If multiple variants have the key, returns a new UnionContext of those values.
+   *
+   * @param {string} key
+   * @returns {VariableContext|null}
+   */
+  get(key) {
+    const results = [];
+    for (const variant of this.variants) {
+      const val = variant.get(key);
+      if (val != null) {
+        results.push(val);
+      }
+    }
+
+    if (results.length === 0) {
+      return null;
+    }
+
+    if (results.length === 1) {
+      return results[0];
+    }
+
+    // return a union when multiple variants exist
+    return new UnionContext(results.map(r => EntriesContext.toVariant(r)));
+  }
+
+  /**
+   * Add a key as a new variant entry.
+   *
+   * @param {string} key
+   * @param {any} value
+   *
+   * @returns {this}
+   */
+  set(key, value) {
+
+    const context = /** @type {this} */ (
+      new UnionContext([
+        ...this.variants,
+        EntriesContext.of({ entries: { [key]: value } })
+      ])
+    );
+
+    return context;
+  }
+}
+
+
 /**
  * An alternative context that holds additional meta-data
  */
@@ -88,32 +168,38 @@ export class EntriesContext extends VariableContext {
   }
 
   /**
-   * @param { EntriesContextValue } context
-   * @param { EntriesContextValue} other
+   * Create a context from one or more values.
    *
-   * @return { EntriesContextValue }
+   * When called with multiple non-nil values, returns a UnionContext that preserves
+   * each variant's distinct shape instead of merging them.
+   * When called with zero or one non-nil value, uses the original merge-based
+   * behavior for backward compatibility.
+   *
+   * @param { ...(VariableContext | EntriesContextValue | any) } contexts
+   * @returns { EntriesContext | UnionContext }
    */
-  static __merge(context, other) {
+  static of(...contexts) {
+    if (contexts.length > 1) {
 
-    const {
-      entries: contextEntries = {},
-      ...contextRest
-    } = this.__unwrap(context);
+      // create a union context preserving each variant's shape
+      return new UnionContext(contexts.map(c => this.toVariant(c)));
+    }
 
-    const {
-      entries: otherEntries = {},
-      ...otherRest
-    } = this.__unwrap(other);
-
-    // @ts-ignore "access to internals"
-    const mergedEntries = super.__merge(contextEntries, otherEntries);
-
-    return {
-      ...contextRest,
-      ...otherRest,
-      entries: mergedEntries
-    };
+    // create new context from key
+    return this.toVariant(contexts[0]);
   }
+
+  /**
+   * Normalize a value to a VariableContext variant.
+   * VariableContext subclasses are returned as-is; plain values are wrapped.
+   *
+   * @param {VariableContext | any} value
+   * @returns {VariableContext}
+   */
+  static toVariant(value) {
+    return value instanceof VariableContext ? value : new this(this.__unwrap(value));
+  }
+
 }
 
 

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -847,15 +847,24 @@ Expression(
 )
 
 
-# Interval (error) { "top": "Expressions" }
+# Interval (error, unclosed)
 
-[a..b;
+[a..b
+
+==>
+
+Expression(
+  SimplePositiveUnaryTest(Interval("[",VariableName(...),VariableName(...),⚠))
+)
+
+
+# Interval (error, to missing)
+
 [a..
 
 ==>
 
-Expressions(
-  SimplePositiveUnaryTest(Interval("[",VariableName(...),VariableName(...),⚠)),
+Expression(
   SimplePositiveUnaryTest(Interval("[",VariableName(...),⚠))
 )
 
@@ -908,15 +917,25 @@ Expression(
   )
 )
 
-# Interval / List (error) { "top": "Expressions" }
 
-[a;
+# Interval / List (error, unclosed)
+
+[a
+
+==>
+
+Expression(
+  SimplePositiveUnaryTest(Interval("[",VariableName(...),⚠))
+)
+
+
+# Interval / List (error, open char)
+
 [
 
 ==>
 
-Expressions(
-  SimplePositiveUnaryTest(Interval("[",VariableName(...),⚠)),
+Expression(
   List("[",⚠)
 )
 

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -91,7 +91,7 @@ describe('custom context', function() {
   });
 
 
-  it('should merge contexts', function() {
+  it('should create union from contexts', function() {
 
     // when
     const context = EntriesContext.of(
@@ -112,15 +112,41 @@ describe('custom context', function() {
     );
 
     // then
-    expect(
-      context.value.entries.a.value.entries
-    ).to.have.keys([
-      'ab', 'ac'
-    ]);
+    expect(context).to.eql({
+      value: {},
+      variants: [
+        {
+          value: {
+            entries: {
+              a: {
+                value: {
+                  entries: {
+                    ab: { value: { atomicValue: 10, entries: {} } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          value: {
+            entries: {
+              a: {
+                value: {
+                  entries: {
+                    ac: { value: { atomicValue: 20, entries: {} } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    });
   });
 
 
-  it('should merge, unwraping nested contexts', function() {
+  it('should create union, unwrapping nested contexts', function() {
 
     const context = EntriesContext.of(
       EntriesContext.of({
@@ -146,11 +172,37 @@ describe('custom context', function() {
     );
 
     // then
-    expect(
-      context.value.entries.a.value.entries
-    ).to.have.keys([
-      'ab', 'ac'
-    ]);
+    expect(context).to.eql({
+      value: {},
+      variants: [
+        {
+          value: {
+            entries: {
+              a: {
+                value: {
+                  entries: {
+                    ab: { value: { atomicValue: 10, entries: {} } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          value: {
+            entries: {
+              a: {
+                value: {
+                  entries: {
+                    ac: { value: { atomicValue: 20, entries: {} } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    });
   });
 
 
@@ -175,9 +227,11 @@ describe('custom context', function() {
 
     // then
     expect(context).to.eql({
-      value: {
-        entries: { }
-      }
+      value: {},
+      variants: [
+        { value: { entries: {} } },
+        { value: { entries: {} } }
+      ]
     });
   });
 
@@ -223,6 +277,18 @@ describe('custom context', function() {
 
       // then
       expect(shape).to.eql(1);
+    });
+
+
+    it('atomic value (null)', function() {
+
+      // then
+      const shape = computedValue(`
+        null
+      `);
+
+      // then
+      expect(shape).to.eql(null);
     });
 
 
@@ -348,7 +414,7 @@ describe('custom context', function() {
 
       // when
       const shape = computedValue(`
-        { zero: 0, emptyString: "" }
+        { zero: 0, emptyString: "", n: null }
       `);
 
       // then
@@ -367,6 +433,12 @@ describe('custom context', function() {
                 atomicValue: '',
                 entries: {}
               }
+            },
+            n: {
+              value: {
+                atomicValue: null,
+                entries: {}
+              }
             }
           }
         }
@@ -383,24 +455,177 @@ describe('custom context', function() {
 
       // then
       expect(shape).to.eql({
+        value: {},
+        variants: [
+          {
+            value: { atomicValue: 1, entries: {} }
+          },
+          {
+            value: { atomicValue: null, entries: {} }
+          },
+          {
+            value: {
+              atomicValue: undefined,
+              entries: {
+                'a +': {
+                  value: { atomicValue: 1, entries: {} }
+                }
+              }
+            }
+          },
+          {
+            value: {
+              atomicValue: undefined,
+              entries: {
+                'b +': {
+                  value: { atomicValue: 2, entries: {} }
+                }
+              }
+            }
+          }
+        ]
+      });
+    });
+
+
+    it('list (preserves distinct atomic shapes)', function() {
+
+      // when
+      const shape = computedValue(`
+        [ 1, true ]
+      `);
+
+      // then
+      // distinct shapes are preserved as variants, not merged
+      expect(shape).to.eql({
+        value: {},
+        variants: [
+          {
+            value: { atomicValue: 1, entries: {} }
+          },
+          {
+            value: { atomicValue: true, entries: {} }
+          }
+        ]
+      });
+    });
+
+
+    it('if expression (preserves branch shapes)', function() {
+
+      // when
+      const shape = computedValue(`
+        if true then { a: 1 } else { b: 2 }
+      `);
+
+      // then
+      // then/else branches are kept as distinct variants
+      expect(shape).to.eql({
+        value: {},
+        variants: [
+          {
+            value: {
+              atomicValue: undefined,
+              entries: {
+                a: { value: { atomicValue: 1, entries: {} } }
+              }
+            }
+          },
+          {
+            value: {
+              atomicValue: undefined,
+              entries: {
+                b: { value: { atomicValue: 2, entries: {} } }
+              }
+            }
+          }
+        ]
+      });
+    });
+
+
+    it('path expression (single branch)', function() {
+
+      // when
+      const shape = computedValue(`
+        [ { a: { c: 1 } }, { b: 2 } ].a
+      `);
+
+      // then
+      expect(shape).to.eql({
         value: {
           atomicValue: undefined,
           entries: {
-            'a +': {
+            c: {
               value: {
                 atomicValue: 1,
-                entries: {}
-              }
-            },
-            'b +': {
-              value: {
-                atomicValue: 2,
                 entries: {}
               }
             }
           }
         }
       });
+    });
+
+
+    it('path expression (single branch yields <null>)', function() {
+
+      // when
+      const shape = computedValue(`
+        [ { a: null }, { b: 1 } ].a
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: null,
+          entries: {}
+        }
+      });
+    });
+
+
+    it('path expression (multiple branches)', function() {
+
+      // when
+      const shape = computedValue(`
+        [ { a: { c: 1 } }, { a: { b: 2 } } ].a
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {},
+        variants: [
+          {
+            value: {
+              atomicValue: undefined,
+              entries: {
+                c: { value: { atomicValue: 1, entries: {} } }
+              }
+            }
+          },
+          {
+            value: {
+              atomicValue: undefined,
+              entries: {
+                b: { value: { atomicValue: 2, entries: {} } }
+              }
+            }
+          }
+        ]
+      });
+    });
+
+
+    it('list (keys accessible across all variants)', function() {
+
+      // when
+      const shape = computedValue(`
+        [ { a: 1 }, { b: 2 } ]
+      `);
+
+      // then
+      expect(shape.getKeys()).to.include.members([ 'a', 'b' ]);
     });
 
 

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -334,6 +334,44 @@ describe('lezer-feel', function() {
             }
           `
         }));
+
+
+        it('nested branched FEEL contexts', verifyParse({
+          context,
+          tracker,
+          expression: `
+            {
+              a: if x0 then {
+                bb: if x1 then key_11 else {
+                  cc: key_444
+                },
+                b: if x2 then {
+                  cc: key_999,
+                  c: if x3 then {
+                    dd: key_51,
+                    d: if x10 then {
+                      ee: key_113,
+                      e: {
+                        f: key_191
+                      }
+                    } else {
+                      e: if x11 then key1333 else key50000
+                    }
+                  } else {
+                    d: if x4 then key_15 else {
+                      cc: key_441
+                    }
+                  }
+                } else {
+                  cc: key_1112
+                }
+              } else {
+                other: key_123
+              }
+            }
+          `
+        }));
+
       });
 
     }


### PR DESCRIPTION
### Which issue does this PR address?

Validates that we can create a custom context that keeps track of different shapes of an element (`variants`):

```javascript
const shape = computedValue(`
  if true then { a: 1 } else { b: 2 }
`);

expect(shape).to.eql({
  value: {},
  variants: [
    {
      value: {
        atomicValue: undefined,
        entries: {
          a: { value: { atomicValue: 1, entries: {} } }
        }
      }
    },
    {
      value: {
        atomicValue: undefined,
        entries: {
          b: { value: { atomicValue: 2, entries: {} } }
        }
      }
    }
  ]
});
```

Closes https://github.com/nikku/lezer-feel/issues/86
