### PR TITLE
feat: annotate function invocations with source expression

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1167,8 +1167,15 @@ export function trackVariables(context = {}, Context = VariableContext) {
         if (name?.raw === 'get value') {
           variables = getContextValue(variables, args);
         } else {
+          const resolved = name?.computedValue();
+
           variables = variables.assign({
-            value: name?.computedValue() || Context.of(undefined)
+            value: resolved || new Context({
+              atomicValue: undefined,
+
+              // @ts-expect-error internal method
+              expression: input.read(input.pos, stack.pos)
+            })
           });
         }
       }

--- a/test/test-custom-context.js
+++ b/test/test-custom-context.js
@@ -672,6 +672,7 @@ describe('custom context', function() {
       expect(shape).to.eql({
         value: {
           atomicValue: undefined,
+          expression: 'abs(-22)',
           entries: {}
         }
       });
@@ -689,6 +690,7 @@ describe('custom context', function() {
       expect(shape).to.eql({
         value: {
           atomicValue: undefined,
+          expression: 'substring("foobar", 3)',
           entries: {}
         }
       });
@@ -706,6 +708,7 @@ describe('custom context', function() {
       expect(shape).to.eql({
         value: {
           atomicValue: undefined,
+          expression: 'now()',
           entries: {}
         }
       });
@@ -723,6 +726,7 @@ describe('custom context', function() {
       expect(shape).to.eql({
         value: {
           atomicValue: undefined,
+          expression: 'abs(round(-22.5))',
           entries: {}
         }
       });
@@ -785,6 +789,7 @@ describe('custom context', function() {
                   'b -': {
                     value: {
                       atomicValue: undefined,
+                      expression: 'abs(x)',
                       entries: {}
                     }
                   }
@@ -819,8 +824,145 @@ describe('custom context', function() {
                   'b -': {
                     value: {
                       atomicValue: undefined,
+                      expression: 'abs(x)',
                       entries: {}
                     }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+
+    it('function invocation (nested branching context via if-else)', function() {
+
+      // when
+      const shape = computedValue(`
+        {
+          a: function() {
+            result: if true then { x: abs(1) } else { y: now() }
+          },
+          b: a()
+        }.b
+      `);
+
+      // then - branches preserved as variants with expressions on unresolved leaves
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            'result': {
+              value: {},
+              variants: [
+                {
+                  value: {
+                    atomicValue: undefined,
+                    entries: {
+                      'x': {
+                        value: {
+                          atomicValue: undefined,
+                          expression: 'abs(1)',
+                          entries: {}
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  value: {
+                    atomicValue: undefined,
+                    entries: {
+                      'y': {
+                        value: {
+                          atomicValue: undefined,
+                          expression: 'now()',
+                          entries: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      });
+    });
+
+
+    it('function invocation (deeply nested branching with mixed resolved and unresolved)', function() {
+
+      // when
+      const shape = computedValue(`
+        {
+          a: function() {
+            level1: {
+              resolved: 42,
+              unresolved: abs(x),
+              nested: if true then { deep: now() } else { deep: round(y) }
+            }
+          },
+          b: a()
+        }.b
+      `);
+
+      // then
+      expect(shape).to.eql({
+        value: {
+          atomicValue: undefined,
+          entries: {
+            'level1': {
+              value: {
+                atomicValue: undefined,
+                entries: {
+                  'resolved': {
+                    value: {
+                      atomicValue: 42,
+                      entries: {}
+                    }
+                  },
+                  'unresolved': {
+                    value: {
+                      atomicValue: undefined,
+                      expression: 'abs(x)',
+                      entries: {}
+                    }
+                  },
+                  'nested': {
+                    value: {},
+                    variants: [
+                      {
+                        value: {
+                          atomicValue: undefined,
+                          entries: {
+                            'deep': {
+                              value: {
+                                atomicValue: undefined,
+                                expression: 'now()',
+                                entries: {}
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        value: {
+                          atomicValue: undefined,
+                          entries: {
+                            'deep': {
+                              value: {
+                                atomicValue: undefined,
+                                expression: 'round(y)',
+                                entries: {}
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
Preserve the FEEL sub-expression text on context nodes produced by function invocations. This enables downstream consumers to display the individual expression (e.g. "abs(x)", "now()") for nested property values that cannot be statically evaluated.

Related to camunda/camunda-modeler#5744

### Proposed changes

Upon incorporating changes from #84, downstream libraries like `variable-resolver` started showing `undefined` for FEEL function invocations residing as a property in `Context` variables as we cannot resolve them at the design time. Since these FEEL expressions reside within a `Context` variable rather than being a direct assignment, their expressions are not provided via lezer-feel and hence, variable-resolver cannot display them.

In other words, these changes enable variable-resolver to show a sub-expression for a variable instead of `null`.

Below, you can see how the following variable assignment value can be shown;

```
{
  a: function() {
    level1: {
      resolved: 42,
      unresolved: abs(x),
      nested: if true then { deep: now() } else { deep: round(y) }
    }
  },
  b: a()
}.b
```

**Before**

<img width="231" alt="image" src="https://github.com/user-attachments/assets/8805072d-9593-4f91-a893-aa38f3fc49ba" />

**After**

<img width="231" alt="image" src="https://github.com/user-attachments/assets/29994889-f2c2-444d-a55d-394dd6ae65dd" />

The revision in the "after" uses https://github.com/bpmn-io/variable-resolver/pull/104 with the following patch;

```diff
@@ -752,6 +749,15 @@ function getInfo(variable) {
 function getInfo(variable) {
   if (!variable) {
     return '';
   }
 
   if (variable.info) {
     return variable.info;
   }
 
   if (!isNil(variable.atomicValue)) {
     if (typeof variable.atomicValue === 'string') {
       return JSON.stringify(variable.atomicValue);
     }
     return '' + variable.atomicValue;
   }
 
+  if (variable.expression) {
+
+    if (variable.expression.startsWith('=')) {
+      return variable.expression;
+    }
+
+    return '=' + variable.expression;
+  }
+
   return '';
 }
```