### PR TITLE
feat: highlight function names in call position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: highlight function names in call position ([#90](https://github.com/nikku/lezer-feel/pull/90))
+
 ## 2.4.0
 
 * `FEAT`: correctly handle function definition shapes ([#71](https://github.com/nikku/lezer-feel/issues/71), [#72](https://github.com/nikku/lezer-feel/pull/72), [#84](https://github.com/nikku/lezer-feel/pull/84))

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -24,6 +24,7 @@ export const feelHighlighting = styleTags({
   'Key/Name! ContextEntryType/Name!': t.definition(t.propertyName),
   'PathExpression/VariableName!': t.function(t.propertyName),
   'FormalParameter/ParameterName!': t.function(t.definition(t.variableName)),
+  'FunctionInvocation/VariableName!': t.function(t.variableName),
   '( )': t.paren,
   '[ ]': t.squareBracket,
   '{ }': t.brace,


### PR DESCRIPTION
This allows HighlightStyle consumers to visually distinguish function calls (e.g. is defined, count, string length) from plain variable references.

**Before**

<img width="494" height="240" alt="image" src="https://github.com/user-attachments/assets/7f670a90-0ab2-4b62-a365-adbc93bb62a9" />


**After**

<img width="626" height="203" alt="image" src="https://github.com/user-attachments/assets/fa615aed-cfb8-4d4c-97fe-427222471ef3" />


### Which issue does this PR address?

Not an issue in this repository, but one in a downstream, [camunda/camunda-modeler#5940](https://github.com/camunda/camunda-modeler/issues/5940).