### PR TITLE
Introduce `PathName` into `PathExpression` to distinguish variable accessed from property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [lezer-feel](https://github.com/nikku/lezer-feel) are doc
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: introduce `PathName` token in a `PathExpression` ([#93](https://github.com/nikku/lezer-feel/pull/93))
+* `FIX`: improve grammer to be able to distinguish parts of a `PathExpression` ([#92](https://github.com/nikku/lezer-feel/issues/92))
+* `FIX`: correct parsing of nested positional parameters ([#80](https://github.com/nikku/lezer-feel/issues/80))
+
+### Breaking Changes
+
+* Introduces `PathName` as a token inside of `PathExpression` ([#93](https://github.com/nikku/lezer-feel/pull/93))
+
 ## 2.5.0
 
 _Many highlighter / tagging related adjustments to improve compatibility with standard themes._

--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -108,7 +108,7 @@ pathExpressionStart[@export] {
 }
 
 PathExpression[@dynamicPrecedence=1] {
-  expression !path pathExpressionStart VariableName
+  expression !path pathExpressionStart PathName
 }
 
 filterExpressionStart[@export] {
@@ -327,6 +327,10 @@ Identifier {
 
 BacktickIdentifier {
   backtickIdentifier
+}
+
+PathName {
+  (!name Identifier ~ident)+ | BacktickIdentifier
 }
 
 VariableName {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -21,7 +21,7 @@ export const feelHighlighting = styleTags({
   'FunctionInvocation/VariableName!': t.function(t.variableName),
   'Name!': t.definition(t.variableName),
   'Key/Name! ContextEntryType/Name!': t.definition(t.propertyName),
-  'PathExpression/VariableName!': t.propertyName,
+  'PathExpression/PathName!': t.propertyName,
   'FormalParameter/ParameterName!': t.function(t.definition(t.variableName)),
   '( )': t.paren,
   '[ ]': t.squareBracket,

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -46,7 +46,8 @@ import {
   nil,
   AdditionalIdentifier,
   FunctionInvocation,
-  functionInvocationStart
+  functionInvocationStart,
+  PathName
 } from './parser.terms.js';
 
 import {
@@ -901,7 +902,7 @@ class Variables {
     }
   }
 
-  resolveName() {
+  resolveName(name) {
 
     const variable = this.tokens.join(' ');
     const tokens = [];
@@ -911,13 +912,13 @@ class Variables {
     });
 
     const variableScope = this.of({
-      name: 'VariableName',
+      name,
       parent: parentScope,
       value: this.get(variable),
       raw: variable
     });
 
-    LOG_VARS && console.log('[%s] resolve name <%s=%s>', variableScope.path, variable, this.get(variable));
+    LOG_VARS && console.log('[%s] resolve %s <%s=%s>', name, variableScope.path, variable, variableScope.value);
 
     return parentScope.pushChild(variableScope);
   }
@@ -1310,7 +1311,13 @@ export function trackVariables(context = {}, Context = VariableContext) {
       if (
         term === VariableName
       ) {
-        return variables.resolveName();
+        return variables.resolveName('VariableName');
+      }
+
+      if (
+        term === PathName
+      ) {
+        return variables.resolveName('PathName');
       }
 
       if (

--- a/test/camunda.txt
+++ b/test/camunda.txt
@@ -10,8 +10,8 @@ baz`
 
 Expressions(
   VariableName(BacktickIdentifier(...)),
-  PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
-  PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
+  PathExpression(VariableName(...), PathName(BacktickIdentifier(...))),
+  PathExpression(VariableName(...), PathName(BacktickIdentifier(...))),
   VariableName(BacktickIdentifier(...))
 )
 

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -2219,6 +2219,21 @@ Expression(
 )
 
 
+# DateTimeLiteral (nested)
+
+date and time(
+  date(
+    time(foo.bar)
+  )
+)
+
+==>
+
+Expression(
+  DateTimeLiteral(...)
+)
+
+
 # Special Function Name / Conjunction
 
 years and months duration() and a > 5

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -253,10 +253,10 @@ Expression(
             ),
           "}"),
         ")"),
-        VariableName(...)
+        PathName(...)
       ),
     ")"),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -311,7 +311,7 @@ Expression(
         ),
       ")"
     ),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -329,7 +329,7 @@ Expression(
         NamedParameter(ParameterName(...),StringLiteral),
         NamedParameter(ParameterName(...),VariableName(...))
       ),")"
-    ),VariableName(...)
+    ),PathName(...)
   )
 )
 
@@ -364,7 +364,7 @@ Expression(
         ),
       ")"
     ),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -398,7 +398,7 @@ Expression(
         "}"))
       ),
     ")"),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -415,15 +415,15 @@ null and true;
 
 Expressions(
   FilterExpression(null,"[",NumericLiteral,"]"),
-  PathExpression(null,VariableName(...)),
+  PathExpression(null,PathName(...)),
   PathExpression(
     PathExpression(
       Context("{",
         ContextEntry(Key(Name(...)),null),
       "}"),
-      VariableName(...)
+      PathName(...)
     ),
-    VariableName(...)
+    PathName(...)
   ),
   Conjunction(null,and,BooleanLiteral),
   ArithmeticExpression(NumericLiteral,ArithOp,null)
@@ -624,7 +624,7 @@ Expression(
     Context("{",
       ContextEntry(Key(Name(...)),NumericLiteral),
     "}"),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -679,7 +679,7 @@ Expression(
       Context("{",
         ContextEntry(Key(Name(...)),NumericLiteral),
       "}"),
-      VariableName(...)
+      PathName(...)
     ),
     ArithOp,
     VariableName(...)
@@ -698,7 +698,7 @@ Expression(
 Expression(
   PathExpression(
     Context(ContextEntry(Key(...), ⚠)),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -730,7 +730,7 @@ Expression(
       ArithmeticExpression(
         PathExpression(
           VariableName(...),
-          VariableName(...)
+          PathName(...)
         ),
         ArithOp,
         NumericLiteral
@@ -808,7 +808,7 @@ Expression(
         ),
       "}"),
     ")"),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -842,7 +842,7 @@ Expressions(
 
 Expression(
   SimplePositiveUnaryTest(
-    Interval("[",PathExpression(VariableName(...),VariableName(...)),VariableName(...),"]")
+    Interval("[",PathExpression(VariableName(...),PathName(...)),VariableName(...),"]")
   )
 )
 
@@ -898,7 +898,7 @@ Expressions(
 Expression(
   PathExpression(
     List(...),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -913,7 +913,7 @@ Expression(
 Expression(
   PathExpression(
     List(...),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -1176,7 +1176,7 @@ Expression(
       InExpression(Name(...),in,IterationContext(List("[","]")))
     ), satisfies, PathExpression(
       VariableName(...),
-      VariableName(...)
+      PathName(...)
     )
   )
 )
@@ -1200,7 +1200,7 @@ Expression(
     ),satisfies,
     PathExpression(
       VariableName(...),
-      VariableName(...)
+      PathName(...)
     )
   )
 )
@@ -1249,7 +1249,7 @@ null[1]
 
 Expressions(
   FilterExpression(VariableName(...),"[",VariableName(...),"]"),
-  PathExpression(FilterExpression(VariableName(...),"[",VariableName(...),"]"),VariableName(...)),
+  PathExpression(FilterExpression(VariableName(...),"[",VariableName(...),"]"),PathName(...)),
   FilterExpression(List("[",StringLiteral,StringLiteral,"]"),"[",StringLiteral,"]"),
   FilterExpression(List(...),"[",NumericLiteral,"]"),
   FilterExpression(List(...),"[",BooleanLiteral,"]"),
@@ -1313,9 +1313,9 @@ Expression(
       Comparison(
         PathExpression(
           PathExpression(
-            VariableName(...),VariableName(...)
+            VariableName(...),PathName(...)
           ),
-          VariableName(...)
+          PathName(...)
         ),CompareOp,NumericLiteral
       ),
     "]"
@@ -1336,8 +1336,8 @@ Expression(
 Expression(
   Context("{",
     ContextEntry(Key(...),List(...)),
-    ContextEntry(Key(...),PathExpression(FilterExpression(...),VariableName(...))),
-    ContextEntry(Key(...),PathExpression(FilterExpression(...),VariableName(...)))
+    ContextEntry(Key(...),PathExpression(FilterExpression(...),PathName(...))),
+    ContextEntry(Key(...),PathExpression(FilterExpression(...),PathName(...)))
   "}")
 )
 
@@ -1356,9 +1356,9 @@ Expression(
 Expression(
   Context("{",
     ContextEntry(Key(...),List(...)),
-    ContextEntry(Key(...),PathExpression(FilterExpression(...),VariableName(...))),
-    ContextEntry(Key(...),PathExpression(FilterExpression(...),VariableName(...))),
-    ContextEntry(Key(...),PathExpression(FilterExpression(...),VariableName(...))),
+    ContextEntry(Key(...),PathExpression(FilterExpression(...),PathName(...))),
+    ContextEntry(Key(...),PathExpression(FilterExpression(...),PathName(...))),
+    ContextEntry(Key(...),PathExpression(FilterExpression(...),PathName(...))),
   "}")
 )
 
@@ -1373,13 +1373,13 @@ a+b.c
 ==>
 
 Expressions(
-  PathExpression(VariableName(...),VariableName(...)),
-  PathExpression(ParenthesizedExpression(...),VariableName(...)),
+  PathExpression(VariableName(...),PathName(...)),
+  PathExpression(ParenthesizedExpression(...),PathName(...)),
   PathExpression(
-    PathExpression(ParenthesizedExpression(...),VariableName(...)),VariableName(...)
+    PathExpression(ParenthesizedExpression(...),PathName(...)),PathName(...)
   ),
   ArithmeticExpression(
-    VariableName(...),ArithOp,PathExpression(VariableName(...),VariableName(...))
+    VariableName(...),ArithOp,PathExpression(VariableName(...),PathName(...))
   )
 )
 
@@ -1394,9 +1394,9 @@ Expression(
   PathExpression(
     PathExpression(
       VariableName(...),
-      VariableName(...)
+      PathName(...)
     ),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -1415,9 +1415,9 @@ Expression(
 Expression(
   Context("{",
     ContextEntry(Key(...),List(...)),
-    ContextEntry(Key(...),PathExpression(VariableName(...),VariableName(...))),
-    ContextEntry(Key(...),PathExpression(VariableName(...),VariableName(...))),
-    ContextEntry(Key(...),PathExpression(VariableName(...),VariableName(...))),
+    ContextEntry(Key(...),PathExpression(VariableName(...),PathName(...))),
+    ContextEntry(Key(...),PathExpression(VariableName(...),PathName(...))),
+    ContextEntry(Key(...),PathExpression(VariableName(...),PathName(...))),
   "}")
 )
 
@@ -1434,7 +1434,7 @@ Expression(
       List(
         "[", "NumericLiteral", "]"
       ),
-      VariableName(...)
+      PathName(...)
     ),
     ArithOp,
     VariableName(...)
@@ -1522,7 +1522,7 @@ Expression(
     ))
   ),return,PathExpression(
     VariableName(...),
-    VariableName(...)
+    PathName(...)
   ))
 )
 
@@ -1563,7 +1563,7 @@ Expression(
         else,
           PathExpression(
             FilterExpression(VariableName(...),"[",NumericLiteral(...),"]"),
-            VariableName(...)
+            PathName(...)
           )
       )
   )
@@ -1583,7 +1583,7 @@ Expression(
   ForExpression(
     for,InExpressions(
       InExpression(Name(...),in,IterationContext(...))
-    ),return,PathExpression(VariableName(...), VariableName(...))
+    ),return,PathExpression(VariableName(...), PathName(...))
   )
 )
 
@@ -1601,7 +1601,7 @@ Expression(
   ForExpression(
     for,InExpressions(
       InExpression(Name(...),in,IterationContext(...))
-    ),return,PathExpression(VariableName(...), VariableName(...))
+    ),return,PathExpression(VariableName(...), PathName(...))
   )
 )
 
@@ -1693,7 +1693,7 @@ Expression(
 Expression(
   PathExpression(
     ParenthesizedExpression(...),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -1707,7 +1707,7 @@ Expression(
 Expression(
   PathExpression(
     ParenthesizedExpression(...),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -1722,9 +1722,9 @@ Expression(
   PathExpression(
     PathExpression(
       ParenthesizedExpression(...),
-      VariableName(...)
+      PathName(...)
     ),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -1817,9 +1817,9 @@ Expression(
           FunctionInvocation(
             VariableName(...),"(",PositionalParameters,")"
           ),
-          VariableName(...)
+          PathName(...)
         ),
-        VariableName(...)
+        PathName(...)
       )
     ),
   "}")
@@ -1942,7 +1942,7 @@ Expressions(
     NamedParameters(
       NamedParameter(
         ParameterName(...),
-        PathExpression(VariableName(...),⚠,VariableName(...))
+        PathExpression(VariableName(...),⚠,PathName(...))
       )
     ),
   ")"),
@@ -1951,7 +1951,7 @@ Expressions(
     NamedParameters(
       NamedParameter(
         ParameterName(...),
-        PathExpression(VariableName(...),⚠,VariableName(...))
+        PathExpression(VariableName(...),⚠,PathName(...))
       )
     ),
   ")")
@@ -2119,9 +2119,9 @@ Expression(
   PathExpression(
     PathExpression(
       DateTimeLiteral(...),
-      VariableName(...)
+      PathName(...)
     ),
-    VariableName(...)
+    PathName(...)
   )
 )
 
@@ -2259,7 +2259,7 @@ Expression(
   Context("{",
     ContextEntry(Key(Name(...)),FunctionDefinition(function,"(",FormalParameters(FormalParameter(ParameterName(...))),")",FunctionBody(ArithmeticExpression(VariableName(...),ArithOp,NumericLiteral)))),
     ContextEntry(Key(Name(...)),FunctionInvocation(VariableName(...),"(",PositionalParameters(VariableName(...)),")")),
-    ContextEntry(Key(Name(...)),FilterExpression(PathExpression(VariableName(...),VariableName(...)),"[",Comparison(VariableName(...),CompareOp,NumericLiteral),"]")),"}")
+    ContextEntry(Key(Name(...)),FilterExpression(PathExpression(VariableName(...),PathName(...)),"[",Comparison(VariableName(...),CompareOp,NumericLiteral),"]")),"}")
 )
 
 
@@ -2281,7 +2281,7 @@ Expression(
     "}")),
     ContextEntry(Key(Name(...)),PathExpression(
       VariableName(...),
-      VariableName(...)
+      PathName(...)
     )),
   "}")
 )
@@ -2308,7 +2308,7 @@ Expressions(
       FormalParameter(ParameterName(Name(Identifier)))
     ),
   ")",FunctionBody(
-    ArithmeticExpression(FunctionInvocation(PathExpression(VariableName(Identifier),VariableName(Identifier)),"(",PositionalParameters,")"),ArithOp,VariableName(Identifier))
+    ArithmeticExpression(FunctionInvocation(PathExpression(VariableName(Identifier),PathName(Identifier)),"(",PositionalParameters,")"),ArithOp,VariableName(Identifier))
   ))
 )
 
@@ -2383,7 +2383,7 @@ a + foo.bar[foo=1]
 Expression(
   ArithmeticExpression(
     VariableName(...),ArithOp,FilterExpression(
-      PathExpression(VariableName(...),VariableName(...)),"[",Comparison(
+      PathExpression(VariableName(...),PathName(...)),"[",Comparison(
         VariableName(...),CompareOp,NumericLiteral
       ),"]"
     )
@@ -2462,7 +2462,7 @@ Expressions(
   DateTimeLiteral(...),
   FunctionInvocation(SpecialFunctionName(...),"(",PositionalParameters,")"),
 
-  PathExpression(FunctionInvocation(...),VariableName(...)),
+  PathExpression(FunctionInvocation(...),PathName(...)),
 
   FunctionInvocation(...),
   FunctionInvocation(...),
@@ -2867,6 +2867,6 @@ foo.`bar-baz`;
 
 Expressions(
   VariableName(...),
-  PathExpression(VariableName(...), VariableName(...)),
-  PathExpression(VariableName(...), VariableName(...))
+  PathExpression(VariableName(...), PathName(...)),
+  PathExpression(VariableName(...), PathName(...))
 )

--- a/test/test-highlight.js
+++ b/test/test-highlight.js
@@ -80,7 +80,7 @@ describe('feel highlighting', function() {
       const spans = getHighlights(expression);
 
       // then
-      expect(spans).to.deep.include({ text: 'foo', cls: 'property' });
+      expect(spans).to.deep.include({ text: 'foo', cls: 'variable' });
       expect(spans).to.deep.include({ text: 'bar', cls: 'property' });
       expect(spans).to.deep.include({ text: 'a', cls: 'variable' });
     });
@@ -320,7 +320,7 @@ for a in b return c`;
       const spans = getHighlights(expression);
 
       // then
-      expect(spans).to.deep.include({ text: 'foo', cls: 'property' });
+      expect(spans).to.deep.include({ text: 'foo', cls: 'variable' });
       expect(spans).to.deep.include({ text: 'bar', cls: 'property' });
     });
 


### PR DESCRIPTION
### Which issue does this PR address?

For path expressions such as `someVariable.someProperty` the library would previously return two `VariableName` tokens wrapped in a `PathExpression` - making it impossible to distinguish variable accessed and property used to access it from each other.

This change introduces `PathName` to `PathExpression` - allowing consumers to clearly tell apart both.

> [!IMPORTANT] 
> This is a breaking change in the library - it changes the output structure of the parse tree.

Closes #92 
