### PR TITLE
fix(grammar): reject "=" and "!=" as unary test prefix operators

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -185,7 +185,6 @@ Comparison {
 }
 
 SimplePositiveUnaryTest {
-  CompareOp<"=" | "!="> endpoint |
   CompareOp<">" | ">=" | "<" | "<="> endpoint |
   Interval
 }

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -159,9 +159,9 @@ Expressions(
 
 # Comparison (simple positive unary tests) { "top": "Expressions" }
 
-(=10) = [10..10];
-(=10) = (=10);
-(!=10) = (!=10)
+(<10) = [10..10];
+(<10) = (<10);
+(>=10) = (>=10)
 
 ==>
 
@@ -2691,6 +2691,17 @@ Expressions(
   SimplePositiveUnaryTest(CompareOp,NumericLiteral),
   SimplePositiveUnaryTest(CompareOp,VariableName(...)),
   SimplePositiveUnaryTest(CompareOp,PathExpression(...))
+)
+
+
+# Simple Positive Unary Test (error, "=" and "!=" are not valid prefix operators)
+
+= "foo"
+
+==>
+
+Expression(
+  ⚠(CompareOp),StringLiteral
 )
 
 

--- a/test/unary-tests.txt
+++ b/test/unary-tests.txt
@@ -88,8 +88,6 @@ UnaryTests(
 
 # Comparison { "top": "UnaryTests" }
 
-= 10,
-!= 10,
 < 10,
 <= 10,
 > 10,
@@ -101,10 +99,25 @@ UnaryTests(PositiveUnaryTests(
   PositiveUnaryTest(...),
   PositiveUnaryTest(...),
   PositiveUnaryTest(...),
-  PositiveUnaryTest(...),
-  PositiveUnaryTest(...),
   PositiveUnaryTest(...)
 ))
+
+
+# Comparison (error, "=" and "!=" are not valid unary test operators) { "top": "UnaryTests" }
+
+= 10,
+!= 10
+
+==>
+
+UnaryTests(
+  ⚠(CompareOp),
+  PositiveUnaryTests(
+    PositiveUnaryTest(NumericLiteral),
+    ⚠(CompareOp),
+    PositiveUnaryTest(NumericLiteral)
+  )
+)
 
 
 # Negation { "top": "UnaryTests" }


### PR DESCRIPTION
**Note**: this fix was proposed by claude. 
It looked at the feel grammar here and the FeelParser.scala from feel-scala.

### Which issue does this PR address?

Closes #99
